### PR TITLE
HEE-90: User groups and security domains setup for LKS document workflow

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-administration.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-administration.yaml
@@ -1,0 +1,24 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-administration:
+      jcr:primaryType: hipposys:domain
+      /content-domain:
+        jcr:primaryType: hipposys:domainrule
+        /administration-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/administration
+      /readonly:
+        jcr:primaryType: hipposys:authrole
+        hipposys:role: readonly
+        hipposys:userrole:
+          .meta:category: system
+          type: string
+          value: xm.content.user
+        hipposys:users:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: []

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks-gallery-and-assets.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks-gallery-and-assets.yaml
@@ -1,0 +1,57 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-lks-gallery-and-assets:
+      jcr:primaryType: hipposys:domain
+      /gallery-domain:
+        jcr:primaryType: hipposys:domainrule
+        /documents-only:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: hippo:availability
+          hipposys:type: String
+          hipposys:value: live
+        /non-publishable:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: nodetype
+          hipposys:type: String
+          hipposys:value: hippostd:publishable
+        /lks-gallery-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/gallery/lks
+      /assets-domain:
+        jcr:primaryType: hipposys:domainrule
+        /documents-only:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: hippo:availability
+          hipposys:type: String
+          hipposys:value: live
+        /non-publishable:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: nodetype
+          hipposys:type: String
+          hipposys:value: hippostd:publishable
+        /lks-gallery-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/assets/lks
+      /rewrite:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [lks-author, lks-editor]
+        hipposys:role: readwrite
+        hipposys:users:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: []

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks-gallery-and-assets.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks-gallery-and-assets.yaml
@@ -42,7 +42,7 @@ definitions:
           hipposys:facet: jcr:path
           hipposys:type: Reference
           hipposys:value: /content/assets/lks
-      /rewrite:
+      /readwrite:
         jcr:primaryType: hipposys:authrole
         hipposys:groups:
           .meta:category: system

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks.yaml
@@ -1,0 +1,44 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-lks:
+      jcr:primaryType: hipposys:domain
+      /document-domain:
+        jcr:primaryType: hipposys:domainrule
+        /lks-folder-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/lks
+      /author:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [lks-author]
+        hipposys:role: author
+      /editor:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [lks-editor]
+        hipposys:role: editor
+      /gallery-domain:
+        jcr:primaryType: hipposys:domainrule
+        /lks-gallery-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/gallery/lks
+      /assets-domain:
+        jcr:primaryType: hipposys:domainrule
+        /lks-assets-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/assets/lks

--- a/repository-data/application/src/main/resources/hcm-config/configuration/groups/lks-author.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/groups/lks-author.yaml
@@ -1,0 +1,16 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:groups/lks-author:
+      jcr:primaryType: hipposys:group
+      hipposys:members:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: [lks-author]
+      hipposys:securityprovider: internal
+      hipposys:userroles:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: [xm.cms.user, xm.content.user, xm.channel.user, xm.channel.viewer,
+          xm.dashboard.user]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/groups/lks-editor.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/groups/lks-editor.yaml
@@ -1,0 +1,16 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:groups/lks-editor:
+      jcr:primaryType: hipposys:group
+      hipposys:members:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: [lks-editor]
+      hipposys:securityprovider: internal
+      hipposys:userroles:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: [xm.cms.user, xm.content.user, xm.channel.user, xm.channel.webmaster,
+          xm.dashboard.user]

--- a/repository-data/application/src/main/resources/hcm-content/content/assets/lks.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/assets/lks.yaml
@@ -1,0 +1,7 @@
+/content/assets/lks:
+  jcr:primaryType: hippogallery:stdAssetGallery
+  jcr:mixinTypes: ['hippo:named', 'mix:versionable']
+  jcr:uuid: ea11ee3a-e081-40e1-acb3-5214de1f1d1f
+  hippo:name: LKS
+  hippostd:foldertype: [new-file-folder]
+  hippostd:gallerytype: ['hippogallery:exampleAssetSet']

--- a/repository-data/development/src/main/resources/hcm-config/lks-author.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/lks-author.yaml
@@ -1,0 +1,13 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:users/lks-author:
+      jcr:primaryType: hipposys:user
+      hipposys:active: true
+      hipposys:password:
+        .meta:category: system
+        value: password1
+      hipposys:passwordlastmodified:
+        .meta:category: system
+      hipposys:previouspasswords:
+        .meta:category: system
+      hipposys:securityprovider: internal

--- a/repository-data/development/src/main/resources/hcm-config/lks-editor.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/lks-editor.yaml
@@ -1,0 +1,13 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:users/lks-editor:
+      jcr:primaryType: hipposys:user
+      hipposys:active: true
+      hipposys:password:
+        .meta:category: system
+        value: password1
+      hipposys:passwordlastmodified:
+        .meta:category: system
+      hipposys:previouspasswords:
+        .meta:category: system
+      hipposys:securityprovider: internal


### PR DESCRIPTION
- `lks-author` & `lks-editor` user group setup.
- Security domains setup for LKS documents, gallery and assets.
- Additional security domain to restrict users of `lks-author` & `lks-editor` groups to edit documents under `/content/documents/administration` so that it could be managed by Site/System Admin.