### PR TITLE
HEE-159: To reload homepage resource bundle

### DIFF
--- a/repository-data/application/src/main/resources/hcm-actions.yaml
+++ b/repository-data/application/src/main/resources/hcm-actions.yaml
@@ -1,3 +1,3 @@
 action-lists:
-  - 1.0.1:
-      /content/documents/administration/labels/global: reload
+  - 1.0.2:
+      /content/documents/administration/labels/homepage: reload


### PR DESCRIPTION
Reload `Homepage` resource bundle to fix missing Homepage labels on brCloud Test (& Staging) environments.

As you know `Global` resource bundle has already been reloaded as part of other PRs.