### PR TITLE
Configure mini hub to appear in channel manager

### DIFF
--- a/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/pages/patient-and-public-information-minihub-page.yaml
+++ b/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/pages/patient-and-public-information-minihub-page.yaml
@@ -1,0 +1,18 @@
+/hst:hst/hst:configurations/lks/hst:workspace/hst:pages/patient-and-public-information-minihub-page:
+  jcr:primaryType: hst:component
+  hst:lastmodified: 2021-03-18T10:58:53.449+07:00
+  hst:referencecomponent: hst:abstractpages/base
+  /main:
+    jcr:primaryType: hst:containercomponent
+    hippo:identifier: 43b034db-240d-480d-9a69-edea2f3c0cd4
+    hst:label: Main MiniHub
+    hst:lastmodified: 2021-03-18T10:59:26.902+07:00
+    hst:xtype: hst.vbox
+    /minihub:
+      jcr:primaryType: hst:containeritemcomponent
+      hst:componentclassname: uk.nhs.hee.web.components.MiniHubComponent
+      hst:iconpath: images/catalog-component-icons/simple-content.svg
+      hst:label: MiniHub
+      hst:parameternames: [document]
+      hst:parametervalues: [minihubs/working-with-the-public]
+      hst:template: minihub-main

--- a/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/sitemap/patient-and-public-information.yaml
+++ b/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/sitemap/patient-and-public-information.yaml
@@ -1,0 +1,9 @@
+/hst:hst/hst:configurations/lks/hst:workspace/hst:sitemap/patient-and-public-information:
+  jcr:primaryType: hst:sitemapitem
+  hst:componentconfigurationid: hst:pages/patient-and-public-information-minihub-page
+  hst:lastmodified: 2021-03-18T10:58:53.449+07:00
+  hst:pagetitle: Patient and public information
+  /_default_:
+    jcr:primaryType: hst:sitemapitem
+    hst:componentconfigurationid: hst:pages/patient-and-public-information-minihub-page
+    hst:pagetitle: Patient and public information

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
@@ -72,6 +72,12 @@ definitions:
               hst:iconpath: images/catalog-component-icons/simple-content.svg
               hst:label: Landing Page
               hst:template: listingpage-main
+            /minihub:
+              jcr:primaryType: hst:containeritemcomponent
+              hst:componentclassname: uk.nhs.hee.web.components.MiniHubComponent
+              hst:iconpath: images/catalog-component-icons/simple-content.svg
+              hst:label: MiniHub
+              hst:template: minihub-main
       /lks:
         jcr:primaryType: hst:configuration
         hst:inheritsfrom: [../common]

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/prototypepages/minihub-page.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/prototypepages/minihub-page.yaml
@@ -1,0 +1,13 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/common/hst:prototypepages/minihub-page:
+      jcr:primaryType: hst:component
+      jcr:mixinTypes: ['hst:prototypemeta']
+      hst:displayname: MiniHub Page
+      hst:primarycontainer: main
+      hst:referencecomponent: hst:abstractpages/base
+      /main:
+        jcr:primaryType: hst:containercomponent
+        hippo:identifier: 43b034db-240d-480d-9a69-edea2f3c0cd4
+        hst:label: Main MiniHub
+        hst:xtype: hst.vbox

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/lks/workspace.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/lks/workspace.yaml
@@ -26,6 +26,7 @@ definitions:
             hippo:identifier: 3e0ca470-dd0e-4884-95f8-7f99c262975e
             hst:label: Home Page Main
             hst:xtype: hst.vbox
+            hst:lastmodified: 2021-03-17T16:05:30.970+07:00
         /pagenotfound:
           jcr:primaryType: hst:containercomponentfolder
           /main:

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/minihub-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/minihub-main.ftl
@@ -1,6 +1,6 @@
 <#include "../../include/imports.ftl">
 <#include "../macros/guidance-content.ftl"/>
-
+<@hst.defineObjects />
 <@hst.setBundle basename="uk.nhs.hee.web.global"/>
 
 <#-- @ftlvariable name="document" type="uk.nhs.hee.web.beans.MiniHub" -->
@@ -33,7 +33,7 @@
                                 <#else>
                                     <li class="nhsuk-contents-list__item">
                                         <a class="nhsuk-contents-list__link"
-                                           href="${accessFromRootHub?then(document.name + '/' + guidance.name, guidance.name)}">${guidance.title}</a>
+                                           href="${accessFromRootHub?then(hstRequestContext.resolvedSiteMapItem.pathInfo + '/' + guidance.name, guidance.name)}">${guidance.title}</a>
                                     </li>
                                 </#if>
                             </#list>
@@ -66,7 +66,7 @@
                         <#if nextGuidance??>
                             <li class="nhsuk-pagination-item--next">
                                 <a class="nhsuk-pagination__link nhsuk-pagination__link--next"
-                                   href="${accessFromRootHub?then(document.name + '/' + nextGuidance.name, nextGuidance.name)}">
+                                   href="${accessFromRootHub?then(hstRequestContext.resolvedSiteMapItem.pathInfo + '/' + nextGuidance.name, nextGuidance.name)}">
                                     <span class="nhsuk-pagination__title"><@fmt.message key="next"/></span>
                                     <span class="nhsuk-u-visually-hidden">:</span>
                                     <span class="nhsuk-pagination__page">${nextGuidance.title}</span>

--- a/site/components/src/main/java/uk/nhs/hee/web/components/MiniHubComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/MiniHubComponent.java
@@ -1,26 +1,32 @@
 package uk.nhs.hee.web.components;
 
-import org.apache.commons.lang3.StringUtils;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
-import org.onehippo.cms7.essentials.components.EssentialsContentComponent;
+import org.hippoecm.hst.core.parameters.ParametersInfo;
+import org.onehippo.cms7.essentials.components.EssentialsDocumentComponent;
 import uk.nhs.hee.web.beans.Guidance;
 import uk.nhs.hee.web.beans.MiniHub;
+import uk.nhs.hee.web.components.info.MiniHubComponentInfo;
 
 import java.util.List;
 
-public class MiniHubComponent extends EssentialsContentComponent {
+@ParametersInfo(type = MiniHubComponentInfo.class)
+public class MiniHubComponent extends EssentialsDocumentComponent {
     @Override
     public void doBeforeRender(final HstRequest request, final HstResponse response) {
         super.doBeforeRender(request, response);
 
-        MiniHub miniHub = (MiniHub) request.getRequestContext().getContentBean();
+        MiniHub miniHub = request.getModel(REQUEST_ATTR_DOCUMENT);
         if (miniHub != null) {
-            String guidanceName = getComponentParameter("guidance");
+            // When the page accessed from URL minihubName/guidanceName, request will be forward to te related _default_ sitemap item
+            boolean accessWithGuidancePath = request.getRequestContext().getResolvedSiteMapItem().getHstSiteMapItem().isWildCard();
             Guidance previousGuidance = null, nextGuidance = null, currentGuidance = null;
             boolean accessFromRootHub = false;
             List<Guidance> guidancePages = miniHub.getGuidancePages();
-            if (StringUtils.isNotEmpty(guidanceName)) {
+
+            if (accessWithGuidancePath) {
+                // The guidance name in URL will be resolved as "1" parameter name
+                String guidanceName = (String) request.getRequestContext().getResolvedSiteMapItem().getLocalParameters().get("1");
                 for (int i = 0; i < guidancePages.size(); i++) {
                     Guidance guidance = guidancePages.get(i);
                     if (guidance.getName().equalsIgnoreCase(guidanceName)) {

--- a/site/components/src/main/java/uk/nhs/hee/web/components/info/MiniHubComponentInfo.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/info/MiniHubComponentInfo.java
@@ -1,0 +1,11 @@
+package uk.nhs.hee.web.components.info;
+
+import org.hippoecm.hst.core.parameters.JcrPath;
+import org.hippoecm.hst.core.parameters.Parameter;
+import org.onehippo.cms7.essentials.components.info.EssentialsDocumentComponentInfo;
+
+public interface MiniHubComponentInfo extends EssentialsDocumentComponentInfo {
+    @Parameter(name = "document", required = true, displayName = "MiniHub Document")
+    @JcrPath(isRelative = true, pickerSelectableNodeTypes = {"hee:MiniHub"})
+    String getDocument();
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/listeners/PageCreateEventListener.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/listeners/PageCreateEventListener.java
@@ -1,5 +1,6 @@
 package uk.nhs.hee.web.listeners;
 
+import org.hippoecm.hst.configuration.HstNodeTypes;
 import org.hippoecm.hst.pagecomposer.jaxrs.api.ChannelEventListenerRegistry;
 import org.hippoecm.hst.pagecomposer.jaxrs.api.PageCreateContext;
 import org.hippoecm.hst.pagecomposer.jaxrs.api.PageCreateEvent;
@@ -36,6 +37,7 @@ public class PageCreateEventListener {
 
         String newPageName = JcrUtils.getNodeNameQuietly(pageActionContext.getNewPageNode());
         // The new page name will have pattern `page-title-page-prototype-name-optional-running-number`
+        // For example `patient-and-public-information-minihub-page` or `patient-and-public-information-minihub-page-1`
         Pattern pattern = Pattern.compile(MINI_HUB_PAGE_PROTOTYPE_NAME + "[-]?[0-9]*$");
         boolean isMiniHubPage = pattern.matcher(newPageName).find();
         if (isMiniHubPage) {
@@ -46,11 +48,11 @@ public class PageCreateEventListener {
     private void processMiniHubPageCreation(PageCreateContext pageActionContext, String newPageName) {
         Node newSiteMapItemNode = pageActionContext.getNewSiteMapItemNode();
         try {
-            Node defaultNode = newSiteMapItemNode.addNode("_default_", "hst:sitemapitem");
-            defaultNode.setProperty("hst:componentconfigurationid", newSiteMapItemNode.getProperty("hst:componentconfigurationid").getString());
-            defaultNode.setProperty("hst:pagetitle", newSiteMapItemNode.getProperty("hst:pagetitle").getString());
+            Node defaultNode = newSiteMapItemNode.addNode(HstNodeTypes.WILDCARD, HstNodeTypes.NODETYPE_HST_SITEMAPITEM);
+            defaultNode.setProperty(HstNodeTypes.SITEMAPITEM_PROPERTY_COMPONENTCONFIGURATIONID, newSiteMapItemNode.getProperty(HstNodeTypes.SITEMAPITEM_PROPERTY_COMPONENTCONFIGURATIONID).getString());
+            defaultNode.setProperty(HstNodeTypes.SITEMAPITEM_PAGE_TITLE, newSiteMapItemNode.getProperty(HstNodeTypes.SITEMAPITEM_PAGE_TITLE).getString());
         } catch (RepositoryException e) {
-            LOGGER.error(String.format("Error on creating _default_ sitemap for MiniHub page %s", newPageName), e);
+            LOGGER.error(String.format("Error on creating %s sitemap item for MiniHub page %s", HstNodeTypes.WILDCARD, newPageName), e);
         }
     }
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/listeners/PageCreateEventListener.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/listeners/PageCreateEventListener.java
@@ -1,0 +1,56 @@
+package uk.nhs.hee.web.listeners;
+
+import org.hippoecm.hst.pagecomposer.jaxrs.api.ChannelEventListenerRegistry;
+import org.hippoecm.hst.pagecomposer.jaxrs.api.PageCreateContext;
+import org.hippoecm.hst.pagecomposer.jaxrs.api.PageCreateEvent;
+import org.hippoecm.repository.util.JcrUtils;
+import org.onehippo.cms7.services.eventbus.Subscribe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import java.util.regex.Pattern;
+
+public class PageCreateEventListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PageCreateEventListener.class);
+    private static final String MINI_HUB_PAGE_PROTOTYPE_NAME = "minihub-page";
+
+    public void init() {
+        ChannelEventListenerRegistry.get().register(this);
+    }
+
+    public void destroy() {
+        ChannelEventListenerRegistry.get().unregister(this);
+    }
+
+    @Subscribe
+    public void onPageEvent(PageCreateEvent event) {
+        if (event.getException() != null) {
+            return;
+        }
+        // DO YOUR STUFF BUT MAKE SURE TO NEVER
+        // SAVE THE JCR SESSION FOR THAT IS ACCESSIBLE VIA
+        // THE PageCopyEvent#getPageActionContext#getRequestContext
+        PageCreateContext pageActionContext = event.getPageActionContext();
+
+        String newPageName = JcrUtils.getNodeNameQuietly(pageActionContext.getNewPageNode());
+        // The new page name will have pattern `page-title-page-prototype-name-optional-running-number`
+        Pattern pattern = Pattern.compile(MINI_HUB_PAGE_PROTOTYPE_NAME + "[-]?[0-9]*$");
+        boolean isMiniHubPage = pattern.matcher(newPageName).find();
+        if (isMiniHubPage) {
+            processMiniHubPageCreation(pageActionContext, newPageName);
+        }
+    }
+
+    private void processMiniHubPageCreation(PageCreateContext pageActionContext, String newPageName) {
+        Node newSiteMapItemNode = pageActionContext.getNewSiteMapItemNode();
+        try {
+            Node defaultNode = newSiteMapItemNode.addNode("_default_", "hst:sitemapitem");
+            defaultNode.setProperty("hst:componentconfigurationid", newSiteMapItemNode.getProperty("hst:componentconfigurationid").getString());
+            defaultNode.setProperty("hst:pagetitle", newSiteMapItemNode.getProperty("hst:pagetitle").getString());
+        } catch (RepositoryException e) {
+            LOGGER.error(String.format("Error on creating _default_ sitemap for MiniHub page %s", newPageName), e);
+        }
+    }
+}

--- a/site/components/src/main/resources/META-INF/hst-assembly/overrides/page-event-listeners.xml
+++ b/site/components/src/main/resources/META-INF/hst-assembly/overrides/page-event-listeners.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean class="uk.nhs.hee.web.listeners.PageCreateEventListener" init-method="init" destroy-method="destroy"/>
+
+</beans>


### PR DESCRIPTION
- Add MiniHub catalog so that editor can drag the component into page container
- Add MiniHub page prototype so that we can customize the workspace's sitemap generation for created page. We need to create the nested _default_ sitemap item.
- Create demo MiniHub page from Experience Manager which is available under local URL http://localhost:8080/site/patient-and-public-information/copyright