### PR TITLE
LKS -> KLS name update

### DIFF
--- a/repository-data/application/src/main/resources/hcm-actions.yaml
+++ b/repository-data/application/src/main/resources/hcm-actions.yaml
@@ -1,3 +1,7 @@
 action-lists:
   - 1.0.2:
       /content/documents/administration/labels/homepage: reload
+  - 1.0.3:
+      /content/documents/lks: reload
+      /content/gallery/lks: reload
+      /content/assets/lks: reload

--- a/repository-data/application/src/main/resources/hcm-actions.yaml
+++ b/repository-data/application/src/main/resources/hcm-actions.yaml
@@ -1,7 +1,3 @@
 action-lists:
   - 1.0.2:
       /content/documents/administration/labels/homepage: reload
-  - 1.0.3:
-      /content/documents/lks: reload
-      /content/gallery/lks: reload
-      /content/assets/lks: reload

--- a/repository-data/application/src/main/resources/hcm-content/content/assets/lks.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/assets/lks.yaml
@@ -2,6 +2,6 @@
   jcr:primaryType: hippogallery:stdAssetGallery
   jcr:mixinTypes: ['hippo:named', 'mix:versionable']
   jcr:uuid: ea11ee3a-e081-40e1-acb3-5214de1f1d1f
-  hippo:name: LKS
+  hippo:name: KLS
   hippostd:foldertype: [new-file-folder]
   hippostd:gallerytype: ['hippogallery:exampleAssetSet']

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/lks.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/lks.yaml
@@ -3,7 +3,7 @@
   jcr:primaryType: hippostd:folder
   jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:referenceable']
   jcr:uuid: 7a39b705-1cac-4076-bc99-726dd5be84e8
-  hippo:name: LKS
+  hippo:name: KLS
   hippostd:foldertype: [new-translated-folder, new-document]
   hippotranslation:id: 996bcac5-86cf-49b5-a7a3-16a74863e814
   hippotranslation:locale: en

--- a/repository-data/application/src/main/resources/hcm-content/content/gallery/lks.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/gallery/lks.yaml
@@ -3,6 +3,6 @@
   jcr:primaryType: hippogallery:stdImageGallery
   jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
   jcr:uuid: becdfcb8-44b8-4a7c-b134-945478a5e838
-  hippo:name: LKS
+  hippo:name: KLS
   hippostd:foldertype: [new-image-folder]
   hippostd:gallerytype: ['hee:imagesetWithCaption']

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/lks/workspace/channel.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/lks/workspace/channel.yaml
@@ -3,7 +3,7 @@ definitions:
     /hst:hst/hst:configurations/lks/hst:workspace/hst:channel:
       .meta:residual-child-node-category: content
       jcr:primaryType: hst:channel
-      hst:name: LKS
+      hst:name: KLS
       hst:type: website
       hst:channelinfoclass: uk.nhs.hee.web.channels.WebsiteInfo
       hst:lastmodifiedby: admin


### PR DESCRIPTION
- Updated name from `LKS` to `KLS` for document, gallery and asset root folders.
- Moved `repository-data/development/src/main/resources/hcm-content/content/documents/lks.yaml` & `repository-data/development/src/main/resources/hcm-content/content/gallery/lks.yaml` under application repository-data so that document and gallery LKS top level folders are bootstrapped on Test, Staging and Production environments.

**Note:** Haven't included content reloads for `/content/documents/lks, /content/gallery/lks & /content/assets/lks` as it would potentially delete these folders (including child nodes) and so the above name change needs to be applied manually on each environments.