### PR TITLE
QuickLinks/Link fields (Required/Optional) Amendment

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/QuickLinks.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/QuickLinks.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: b7be3bea-5b7a-41d7-9e5f-9164e29edb83
+          jcr:uuid: 1edf1b82-51de-4fa3-95ea-5df1a786cf26
           hipposysedit:node: true
           hipposysedit:supertype: ['hippo:compound', 'hippostd:relaxed']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -23,7 +23,6 @@ definitions:
             hipposysedit:path: hee:title
             hipposysedit:primary: false
             hipposysedit:type: String
-            hipposysedit:validators: [required]
           /links:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -32,7 +31,6 @@ definitions:
             hipposysedit:path: hee:links
             hipposysedit:primary: false
             hipposysedit:type: hee:link
-            hipposysedit:validators: [required]
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
@@ -41,7 +39,7 @@ definitions:
           /hee:links:
             jcr:primaryType: hee:link
             jcr:mixinTypes: ['mix:referenceable']
-            jcr:uuid: f91b7af6-5de0-41b6-95ae-ad2b93b6c5d1
+            jcr:uuid: 3ba70784-4d65-4138-b2b9-e9834a8560bd
             hee:text: ''
             hee:url: ''
             hippostd:holder: holder
@@ -72,6 +70,7 @@ definitions:
             field: title
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
+            hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
           /links:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/link.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/link.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: f14155a1-70ab-4ba2-a0f4-e45cf090213f
+          jcr:uuid: eabaa0be-a215-49fd-af3e-94114ab727f4
           hipposysedit:node: true
           hipposysedit:supertype: ['hippo:compound', 'hippostd:relaxed']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -23,7 +23,6 @@ definitions:
             hipposysedit:path: hee:text
             hipposysedit:primary: false
             hipposysedit:type: String
-            hipposysedit:validators: [required]
           /url:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -53,7 +52,7 @@ definitions:
           jcr:mixinTypes: ['mix:referenceable']
           hee:text: ''
           hee:url: ''
-          jcr:uuid: d0a007cc-9311-4031-90c7-25065f48bed5
+          jcr:uuid: 517258bf-2ecb-4e03-99e6-a22cff38fd0b
           hippostdpubwf:lastModificationDate: 2021-01-27T11:56:00.098Z
           hippostdpubwf:creationDate: 2021-01-27T11:56:00.099Z
           /hee:document:
@@ -76,6 +75,7 @@ definitions:
             field: text
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
+            hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
           /document:

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/lks.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/lks.yaml
@@ -2,4 +2,5 @@
   jcr:primaryType: hippostd:folder
   jcr:mixinTypes: ['mix:versionable']
   jcr:uuid: ed63d279-9385-4f26-901e-96848b3fba02
+  hippo:name: kls
   hippostd:foldertype: [new-resource-bundle, new-untranslated-folder]

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/action-link.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/action-link.ftl
@@ -11,14 +11,16 @@
             <#assign link = "${actionLink.link.url}">
             <#assign openInNewWindow=true/>
         </#if>
-        <div class="nhsuk-action-link">
-            <a class="nhsuk-action-link__link" href="${link}" ${openInNewWindow?then('target="_blank"', '')}>
-                <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path d="M12 2a10 10 0 0 0-9.95 9h11.64L9.74 7.05a1 1 0 0 1 1.41-1.41l5.66 5.65a1 1 0 0 1 0 1.42l-5.66 5.65a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41L13.69 13H2.05A10 10 0 1 0 12 2z"></path>
-                </svg>
-                <span class="nhsuk-action-link__text">${actionLink.link.text}</span>
-            </a>
-        </div>
+        <#if actionLink.link.text?has_content && link?has_content>
+            <div class="nhsuk-action-link">
+                <a class="nhsuk-action-link__link" href="${link}" ${openInNewWindow?then('target="_blank"', '')}>
+                    <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path d="M12 2a10 10 0 0 0-9.95 9h11.64L9.74 7.05a1 1 0 0 1 1.41-1.41l5.66 5.65a1 1 0 0 1 0 1.42l-5.66 5.65a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41L13.69 13H2.05A10 10 0 1 0 12 2z"></path>
+                    </svg>
+                    <span class="nhsuk-action-link__text">${actionLink.link.text}</span>
+                </a>
+            </div>
+        </#if>
     </#if>
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/back-link.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/back-link.ftl
@@ -3,12 +3,14 @@
 <#import "./link.ftl" as hlink>
 
 <#macro backLink link>
-    <div class="nhsuk-back-link">
-        <@hlink.link link=link cssClassName="nhsuk-back-link__link">
-            <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-            </svg>
-            ${link.text}
-        </@hlink.link>
-    </div>
+    <#if link.text?has_content>
+        <div class="nhsuk-back-link">
+            <@hlink.link link=link cssClassName="nhsuk-back-link__link">
+                <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
+                </svg>
+                ${link.text}
+            </@hlink.link>
+        </div>
+    </#if>
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/content-cards.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/content-cards.ftl
@@ -9,14 +9,22 @@
     </#if>
     <ul class="nhsuk-grid-row nhsuk-card-group">
         <#list contentCards.cards as contentCard>
+            <#if contentCard.header.text?has_content && (contentCard.header.document?? || contentCard.header.url?has_content)>
+                <#assign clickableCard=true/>
+            <#else>
+                <#assign clickableCard=false/>
+            </#if>
+
             <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-                <div class="nhsuk-card nhsuk-card--clickable">
+                <div class="nhsuk-card ${clickableCard?then('nhsuk-card--clickable', 'nhsuk-card')}">
                     <div class="nhsuk-card__content">
-                        <h3 class="nhsuk-card__heading nhsuk-heading-m">
-                            <@hlink.link link=contentCard.header cssClassName="nhsuk-card__link">
-                                ${contentCard.header.text}
-                            </@hlink.link>
-                        </h3>
+                        <#if clickableCard>
+                            <h3 class="nhsuk-card__heading nhsuk-heading-m">
+                                <@hlink.link link=contentCard.header cssClassName="nhsuk-card__link">
+                                    ${contentCard.header.text}
+                                </@hlink.link>
+                            </h3>
+                        </#if>
                         <p class="nhsuk-card__description">${contentCard.description}</p>
                     </div>
                 </div>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/link.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/link.ftl
@@ -1,7 +1,7 @@
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
 
 <#macro link link cssClassName>
-    <#if link??>
+    <#if link?? && (link.document?? || link.url?has_content)>
         <#if link.document??>
             <a class="${cssClassName}" href="<@hst.link hippobean=link.document/>"><#nested></a>
         <#else>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/quick-links.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/quick-links.ftl
@@ -3,18 +3,21 @@
 <#import "./link.ftl" as hlink>
 
 <#macro quickLinks quickLinks>
-    <#if quickLinks?? && quickLinks?size != 0>
+    <#if quickLinks?? && quickLinks.title?has_content && quickLinks.links?? && quickLinks.links?size != 0>
         <div class="nhsuk-grid-column-one-third">
             <div class="nhsuk-card">
                 <div class="nhsuk-card__content">
                     <h3 class="nhsuk-card__heading">${quickLinks.title}</h3>
+
                     <ul class="nhsuk-related-links-card__list">
                         <#list quickLinks.links as quickLink>
-                            <li>
-                                <@hlink.link link=quickLink cssClassName="nhsuk-related-links-card__link">
-                                    ${quickLink.text}
-                                </@hlink.link>
-                            </li>
+                            <#if quickLink.text?has_content>
+                                <li>
+                                    <@hlink.link link=quickLink cssClassName="nhsuk-related-links-card__link">
+                                        ${quickLink.text}
+                                    </@hlink.link>
+                                </li>
+                            </#if>
                         </#list>
                     </ul>
                 </div>


### PR DESCRIPTION
- Made (Link) `text` field of `link` CompoundType as optional.
- Made `title` & `links` fields of `QuickLinks` CompoundType are optional.
- Amended all `link` compound type based freemarker templates to render links when link text and document/url are available.