### PR TITLE
HEE-189: Do not show duplicate guidance title on the mini hub

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
@@ -1,15 +1,17 @@
 <#include "../../include/imports.ftl">
 <#import "../macros/components.ftl" as hee>
 
-<#macro guidance guidanceDocument>
+<#macro guidance guidanceDocument showTitle=true>
 <#-- @ftlvariable name="guidanceDocument" type="uk.nhs.hee.web.beans.Guidance" -->
     <#if guidanceDocument??>
         <div class="nhsuk-width-container">
-            <div class="nhsuk-grid-row">
-                <div class="nhsuk-grid-column-two-thirds">
-                    <h1>${guidanceDocument.title}</h1>
+            <#if showTitle>
+                <div class="nhsuk-grid-row">
+                    <div class="nhsuk-grid-column-two-thirds">
+                        <h1>${guidanceDocument.title}</h1>
+                    </div>
                 </div>
-            </div>
+            </#if>
 
             <article>
                 <div class="nhsuk-grid-row">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/minihub-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/minihub-main.ftl
@@ -43,7 +43,7 @@
 
             <article>
                 <#if currentGuidance??>
-                    <@guidance guidanceDocument=currentGuidance/>
+                    <@guidance guidanceDocument=currentGuidance showTitle=false/>
                 </#if>
                 <nav class="nhsuk-pagination" role="navigation" aria-label="Pagination">
                     <ul class="nhsuk-list nhsuk-pagination__list">


### PR DESCRIPTION
Right now the when the guidance is embedded in the MiniHub page, its title has been shown duplicated at both top of the page and below the content list. This PR will hide the one which located under the content list.