### PR TITLE
HEE-196: Add reusable RichText document type

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-richtext-block.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-richtext-block.yaml
@@ -1,0 +1,10 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:queries/hippo:templates/new-richtext-block:
+      jcr:primaryType: hippostd:templatequery
+      hippostd:modify: [./_name, $name, './hippotranslation:locale', $inherited, './hippotranslation:id',
+        $uuid, './hippostdpubwf:createdBy', $holder, './hippostdpubwf:creationDate',
+        $now, './hippostdpubwf:lastModifiedBy', $holder, './hippostdpubwf:lastModificationDate',
+        $now, './hippostd:holder', $holder]
+      jcr:language: xpath
+      jcr:statement: //element(*,hipposysedit:namespacefolder)/element(*,mix:referenceable)/element(*,hipposysedit:templatetype)/hipposysedit:prototypes/element(hipposysedit:prototype,hee:richTextBlock)

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/templates.yaml
@@ -17,6 +17,7 @@ definitions:
       new-afterform-document: new AfterForm document
       new-content-card: new content card
       new-listing-document: new listing document
+      new-richtext-block: new RichText block
     /hippo:configuration/hippo:translations/hippo:templates/fr:
       new-resource-bundle: nouveau resource bundle
       new-untranslated-folder: nouveau dossier non traduit

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee-cms-platform.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee-cms-platform.cnd
@@ -29,6 +29,12 @@
 [hee:QuickLinks] > hippo:compound, hippostd:relaxed
   orderable
 
+[hee:richTextBlock] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
+  orderable
+
+[hee:richTextReference] > hippo:compound, hippostd:relaxed
+  orderable
+
 [hee:StatementBlock] > hippo:compound, hippostd:relaxed
   orderable
 
@@ -46,13 +52,13 @@
 
 [hee:imagesetWithCaption] > hippogallery:imageset, hippogallery:relaxed
 
+[hee:landingPage] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
+  orderable
+
 [hee:link] > hippo:compound, hippostd:relaxed
   orderable
 
 [hee:listingPage] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
-  orderable
-
-[hee:landingPage] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
   orderable
 
 [hee:pageLastNextReview] > hippo:compound, hippostd:relaxed

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: c821286f-78c5-4510-9d07-56f7c5a1c8c3
+          jcr:uuid: f92af292-f8fa-4a2d-918d-21f312168840
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -77,7 +77,7 @@ definitions:
           jcr:mixinTypes: ['mix:referenceable']
           hee:title: ''
           hee:summary: ''
-          jcr:uuid: d9e5bf15-a0eb-44ed-8805-38d8bc08d0fa
+          jcr:uuid: 695769a6-7b03-473a-9709-e10d5a57fb93
           hippostdpubwf:lastModificationDate: 2021-01-27T11:49:03.685Z
           hippostdpubwf:creationDate: 2021-01-27T11:49:03.686Z
           /hee:relatedContent:
@@ -99,7 +99,7 @@ definitions:
             /hee:links:
               jcr:primaryType: hee:link
               jcr:mixinTypes: ['mix:referenceable']
-              jcr:uuid: b410343a-ee12-4d01-85d7-74f5c3bacd24
+              jcr:uuid: 7307c732-e8d0-40a0-a385-b369499db74f
               hee:text: ''
               hee:url: ''
               hippostd:holder: holder
@@ -156,7 +156,7 @@ definitions:
           /contentBlocks:
             jcr:primaryType: frontend:plugin
             caption: Content Blocks
-            compoundList: hippostd:html,hippogallerypicker:imagelink,hee:StatementBlock,hee:YellowAlertBlock,hee:ActionLink
+            compoundList: hippostd:html,hippogallerypicker:imagelink,hee:StatementBlock,hee:YellowAlertBlock,hee:ActionLink,hee:richTextReference
             contentPickerType: links
             field: contentBlocks
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/richTextBlock.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/richTextBlock.yaml
@@ -1,0 +1,63 @@
+definitions:
+  config:
+    /hippo:namespaces/hee/richTextBlock:
+      jcr:primaryType: hipposysedit:templatetype
+      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      jcr:uuid: ed63aeec-776e-48dd-befa-929f7d099457
+      /hipposysedit:nodetype:
+        jcr:primaryType: hippo:handle
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: e46c8808-111d-447f-a450-c685ab72e032
+        /hipposysedit:nodetype:
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:mixinTypes: ['hipposysedit:remodel', 'mix:referenceable']
+          jcr:uuid: dc65ebab-4b48-403a-826c-d472d9a2bf7b
+          hipposysedit:node: true
+          hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
+          hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
+          /html:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:html
+            hipposysedit:primary: false
+            hipposysedit:type: hippostd:html
+            hipposysedit:validators: [required]
+      /hipposysedit:prototypes:
+        jcr:primaryType: hipposysedit:prototypeset
+        /hipposysedit:prototype:
+          jcr:primaryType: hee:richTextBlock
+          jcr:mixinTypes: ['mix:referenceable']
+          jcr:uuid: f575a1dc-4c6d-4090-8ed0-61d0b79b238a
+          hippostd:holder: holder
+          hippostd:state: draft
+          hippostdpubwf:createdBy: ''
+          hippostdpubwf:creationDate: 2021-04-15T09:22:58.236+07:00
+          hippostdpubwf:lastModificationDate: 2021-04-15T09:22:58.236+07:00
+          hippostdpubwf:lastModifiedBy: ''
+          hippotranslation:id: document-type-locale-id
+          hippotranslation:locale: document-type-locale
+          /hee:html:
+            jcr:primaryType: hippostd:html
+            hippostd:content: ''
+      /editor:templates:
+        jcr:primaryType: editor:templateset
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties: [mode]
+          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
+          frontend:services: [wicket.id, validator.id]
+          /root:
+            jcr:primaryType: frontend:plugin
+            item: ${cluster.id}.field
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /html:
+            jcr:primaryType: frontend:plugin
+            caption: HTML
+            field: html
+            hint: ''
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/richTextReference.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/richTextReference.yaml
@@ -1,0 +1,54 @@
+definitions:
+  config:
+    /hippo:namespaces/hee/richTextReference:
+      jcr:primaryType: hipposysedit:templatetype
+      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      jcr:uuid: 1d032959-1a81-4c70-aa9b-cd3daf04f546
+      /hipposysedit:nodetype:
+        jcr:primaryType: hippo:handle
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: d14cd78e-804e-42c1-bc28-fa435789e5a9
+        /hipposysedit:nodetype:
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
+          jcr:uuid: 90d4f172-2053-4c79-bf44-75bf7d4b7c03
+          hipposysedit:node: true
+          hipposysedit:supertype: ['hippo:compound', 'hippostd:relaxed']
+          hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
+          /richTextBlock:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:richTextBlock
+            hipposysedit:primary: false
+            hipposysedit:type: hippo:mirror
+            hipposysedit:validators: [required]
+      /hipposysedit:prototypes:
+        jcr:primaryType: hipposysedit:prototypeset
+        /hipposysedit:prototype:
+          jcr:primaryType: hee:richTextReference
+          /hee:richTextBlock:
+            jcr:primaryType: hippo:mirror
+            hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+      /editor:templates:
+        jcr:primaryType: editor:templateset
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties: [mode]
+          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
+          frontend:services: [wicket.id, validator.id]
+          /root:
+            jcr:primaryType: frontend:plugin
+            item: ${cluster.id}.field
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /richTextBlock:
+            jcr:primaryType: frontend:plugin
+            caption: RichTextBlock
+            field: richTextBlock
+            hint: ''
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              nodetypes: ['hee:richTextBlock']

--- a/repository-data/development/src/main/resources/hcm-actions.yaml
+++ b/repository-data/development/src/main/resources/hcm-actions.yaml
@@ -18,3 +18,6 @@ action-lists:
       /content/documents/lks/listing-pages: reload
   - 1.0.8:
       /content/documents/lks/bulletins: reload
+  - 1.0.9:
+      /content/documents/lks/common: reload
+      /content/documents/lks/guidance-pages: reload

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
@@ -1525,3 +1525,66 @@
           /hee:document:
             jcr:primaryType: hippo:mirror
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+  /richtext-blocks:
+    jcr:primaryType: hippostd:folder
+    jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
+    jcr:uuid: 69c2ec2a-0d9c-4a07-92b2-00cc23aa5ef2
+    hippo:name: RichText Blocks
+    hippostd:foldertype: [new-richtext-block]
+    hippotranslation:id: 41a6b328-6259-4f58-9a56-9f559480c3a5
+    hippotranslation:locale: en
+    /reusable-richtextblock:
+      jcr:primaryType: hippo:handle
+      jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
+      jcr:uuid: 533d8296-ed52-48fe-ab4c-b89e00268a68
+      hippo:name: Reusable RichTextBlock
+      hippo:versionHistory: b4387a57-8af7-4ffc-a614-d6b3420d080f
+      /reusable-richtextblock[1]:
+        jcr:primaryType: hee:richTextBlock
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: aca124ae-9ed8-404d-8555-c65a63277c62
+        hippo:availability: []
+        hippostd:retainable: false
+        hippostd:state: draft
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2021-04-15T16:43:49.997+07:00
+        hippostdpubwf:lastModificationDate: 2021-04-15T18:40:26.931+07:00
+        hippostdpubwf:lastModifiedBy: admin
+        hippotranslation:id: 066502c3-5155-44fa-9f92-4aeba5c72c5e
+        hippotranslation:locale: en
+        /hee:html:
+          jcr:primaryType: hippostd:html
+          hippostd:content: <p>This is <strong>reusable </strong>RichTextBlock</p>
+      /reusable-richtextblock[2]:
+        jcr:primaryType: hee:richTextBlock
+        jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+        jcr:uuid: f0c092b0-3972-408b-a057-e172ce36e7a5
+        hippo:availability: [preview]
+        hippostd:retainable: false
+        hippostd:state: unpublished
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2021-04-15T16:43:49.997+07:00
+        hippostdpubwf:lastModificationDate: 2021-04-15T18:40:31.807+07:00
+        hippostdpubwf:lastModifiedBy: admin
+        hippotranslation:id: 066502c3-5155-44fa-9f92-4aeba5c72c5e
+        hippotranslation:locale: en
+        /hee:html:
+          jcr:primaryType: hippostd:html
+          hippostd:content: <p>This is <strong>reusable </strong>RichTextBlock</p>
+      /reusable-richtextblock[3]:
+        jcr:primaryType: hee:richTextBlock
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: 01d8bee1-215c-419a-b4f5-28663ed5dbea
+        hippo:availability: [live]
+        hippostd:retainable: false
+        hippostd:state: published
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2021-04-15T16:43:49.997+07:00
+        hippostdpubwf:lastModificationDate: 2021-04-15T18:40:31.807+07:00
+        hippostdpubwf:lastModifiedBy: admin
+        hippostdpubwf:publicationDate: 2021-04-15T18:40:33.875+07:00
+        hippotranslation:id: 066502c3-5155-44fa-9f92-4aeba5c72c5e
+        hippotranslation:locale: en
+        /hee:html:
+          jcr:primaryType: hippostd:html
+          hippostd:content: <p>This is <strong>reusable </strong>RichTextBlock</p>

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/guidance-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/guidance-pages.yaml
@@ -12,7 +12,7 @@
     jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
     jcr:uuid: 9071bfc1-35e4-4cb8-852c-c91f97fb43f0
     hippo:name: Copyright
-    hippo:versionHistory: 1bbd6c12-2e77-4a16-894d-d384f6055250
+    hippo:versionHistory: 80bf48c1-5a98-4d72-bdf0-079ddb273a61
     /copyright[1]:
       jcr:primaryType: hee:guidance
       jcr:mixinTypes: ['mix:versionable']
@@ -25,7 +25,7 @@
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-03T15:52:21.360+07:00
-      hippostdpubwf:lastModificationDate: 2021-03-29T14:07:48.486+07:00
+      hippostdpubwf:lastModificationDate: 2021-04-15T16:44:13.509+07:00
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 203579fe-0110-4d7e-a784-29206ca94a04
       hippotranslation:locale: en
@@ -232,6 +232,11 @@
           /hee:document:
             jcr:primaryType: hippo:mirror
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+      /hee:contentBlocks[8]:
+        jcr:primaryType: hee:richTextReference
+        /hee:richTextBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 533d8296-ed52-48fe-ab4c-b89e00268a68
     /copyright[2]:
       jcr:primaryType: hee:guidance
       jcr:mixinTypes: ['mix:referenceable']
@@ -244,7 +249,7 @@
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-03T15:52:21.360+07:00
-      hippostdpubwf:lastModificationDate: 2021-03-29T14:06:55.037+07:00
+      hippostdpubwf:lastModificationDate: 2021-04-15T16:40:34.413+07:00
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 203579fe-0110-4d7e-a784-29206ca94a04
       hippotranslation:locale: en
@@ -401,12 +406,8 @@
         hee:title: Related posts
         /hee:links[1]:
           jcr:primaryType: hee:link
-          jcr:mixinTypes: ['mix:referenceable']
-          jcr:uuid: 8bfb940c-983f-4778-9ad3-fed1b1204509
           hee:text: Expert searching
           hee:url: /
-          hippostd:holder: holder
-          hippostd:state: draft
           hippostdpubwf:createdBy: ''
           hippostdpubwf:creationDate: 2021-01-27T11:56:00.099Z
           hippostdpubwf:lastModificationDate: 2021-01-27T11:56:00.098Z
@@ -418,12 +419,8 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[2]:
           jcr:primaryType: hee:link
-          jcr:mixinTypes: ['mix:referenceable']
-          jcr:uuid: 127f7f65-eec1-47ed-8d2d-7c45cf2c478b
           hee:text: Search bank
           hee:url: /
-          hippostd:holder: holder
-          hippostd:state: draft
           hippostdpubwf:createdBy: ''
           hippostdpubwf:creationDate: 2021-01-27T11:56:00.099Z
           hippostdpubwf:lastModificationDate: 2021-01-27T11:56:00.098Z
@@ -435,12 +432,8 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[3]:
           jcr:primaryType: hee:link
-          jcr:mixinTypes: ['mix:referenceable']
-          jcr:uuid: 09ac7064-1189-4869-b806-76859f7294d7
           hee:text: Costing
           hee:url: /
-          hippostd:holder: holder
-          hippostd:state: draft
           hippostdpubwf:createdBy: ''
           hippostdpubwf:creationDate: 2021-01-27T11:56:00.099Z
           hippostdpubwf:lastModificationDate: 2021-01-27T11:56:00.098Z
@@ -452,12 +445,8 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[4]:
           jcr:primaryType: hee:link
-          jcr:mixinTypes: ['mix:referenceable']
-          jcr:uuid: 19183f1d-35cb-40fe-9606-ac22a0c5e507
           hee:text: Search training
           hee:url: /
-          hippostd:holder: holder
-          hippostd:state: draft
           hippostdpubwf:createdBy: ''
           hippostdpubwf:creationDate: 2021-01-27T11:56:00.099Z
           hippostdpubwf:lastModificationDate: 2021-01-27T11:56:00.098Z
@@ -467,6 +456,11 @@
           /hee:document:
             jcr:primaryType: hippo:mirror
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+      /hee:contentBlocks[8]:
+        jcr:primaryType: hee:richTextReference
+        /hee:richTextBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 533d8296-ed52-48fe-ab4c-b89e00268a68
     /copyright[3]:
       jcr:primaryType: hee:guidance
       jcr:mixinTypes: ['mix:referenceable']
@@ -479,9 +473,9 @@
       hippostd:state: published
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-03T15:52:21.360+07:00
-      hippostdpubwf:lastModificationDate: 2021-03-29T14:07:48.486+07:00
+      hippostdpubwf:lastModificationDate: 2021-04-15T16:44:13.509+07:00
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2021-03-29T14:07:52.691+07:00
+      hippostdpubwf:publicationDate: 2021-04-15T16:44:15.506+07:00
       hippotranslation:id: 203579fe-0110-4d7e-a784-29206ca94a04
       hippotranslation:locale: en
       /hee:contentBlocks[1]:
@@ -687,6 +681,11 @@
           /hee:document:
             jcr:primaryType: hippo:mirror
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+      /hee:contentBlocks[8]:
+        jcr:primaryType: hee:richTextReference
+        /hee:richTextBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 533d8296-ed52-48fe-ab4c-b89e00268a68
   /introduction:
     jcr:primaryType: hippo:handle
     jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
@@ -30,6 +30,9 @@
                                             <#case "org.hippoecm.hst.content.beans.standard.HippoHtml">
                                                 <@hst.html hippohtml=block/>
                                                 <#break>
+                                            <#case "uk.nhs.hee.web.beans.RichTextReference">
+                                                <@hst.html hippohtml=block.richTextBlock.html/>
+                                                <#break>
                                             <#case "uk.nhs.hee.web.beans.StatementBlock">
                                                 <@hee.statementBlock block=block/>
                                                 <#break>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/RichTextBlock.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/RichTextBlock.java
@@ -1,0 +1,19 @@
+package uk.nhs.hee.web.beans;
+
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+
+@HippoEssentialsGenerated(internalName = "hee:richTextBlock")
+@Node(jcrType = "hee:richTextBlock")
+public class RichTextBlock extends BaseDocument {
+    @HippoEssentialsGenerated(internalName = "hee:name")
+    public String getName() {
+        return getSingleProperty("hee:name");
+    }
+
+    @HippoEssentialsGenerated(internalName = "hee:html")
+    public HippoHtml getHtml() {
+        return getHippoHtml("hee:html");
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/RichTextReference.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/RichTextReference.java
@@ -1,0 +1,15 @@
+package uk.nhs.hee.web.beans;
+
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+
+@HippoEssentialsGenerated(internalName = "hee:richTextReference")
+@Node(jcrType = "hee:richTextReference")
+public class RichTextReference extends HippoCompound {
+    @HippoEssentialsGenerated(internalName = "hee:richTextBlock")
+    public HippoBean getRichTextBlock() {
+        return getLinkedBean("hee:richTextBlock", HippoBean.class);
+    }
+}


### PR DESCRIPTION
- Add new document type RichTextBlock with html field
- Add new compound type RichTextReference which have a link which can reference to RichTextBlock
- In the guidance page's content block, configure so that user can pick RichTextReference from here.