### PR TITLE
HEE-210: Enhance guidance navigation when putting MiniHub in IA with nested URLs

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/minihub-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/minihub-main.ftl
@@ -3,7 +3,9 @@
 <@hst.defineObjects />
 <@hst.setBundle basename="uk.nhs.hee.web.global"/>
 
+<#-- @ftlvariable name="hstRequestContext" type="org.hippoecm.hst.core.request.HstRequestContext" -->
 <#-- @ftlvariable name="document" type="uk.nhs.hee.web.beans.MiniHub" -->
+<#-- @ftlvariable name="minihubName" type="java.lang.String" -->
 <#-- @ftlvariable name="currentGuidance" type="uk.nhs.hee.web.beans.Guidance" -->
 <#-- @ftlvariable name="previousGuidance" type="uk.nhs.hee.web.beans.Guidance" -->
 <#-- @ftlvariable name="nextGuidance" type="uk.nhs.hee.web.beans.Guidance" -->
@@ -32,7 +34,7 @@
                                 <#else>
                                     <li class="nhsuk-contents-list__item">
                                         <a class="nhsuk-contents-list__link"
-                                           href="${accessFromRootHub?then(hstRequestContext.resolvedSiteMapItem.pathInfo + '/' + guidance.name, guidance.name)}">${guidance.title}</a>
+                                           href="${accessFromRootHub?then(minihubName + '/' + guidance.name, guidance.name)}">${guidance.title}</a>
                                     </li>
                                 </#if>
                             </#list>
@@ -64,7 +66,7 @@
                         <#if nextGuidance??>
                             <li class="nhsuk-pagination-item--next">
                                 <a class="nhsuk-pagination__link nhsuk-pagination__link--next"
-                                   href="${accessFromRootHub?then(hstRequestContext.resolvedSiteMapItem.pathInfo + '/' + nextGuidance.name, nextGuidance.name)}">
+                                   href="${accessFromRootHub?then(minihubName + '/' + nextGuidance.name, nextGuidance.name)}">
                                     <span class="nhsuk-pagination__title"><@fmt.message key="next"/></span>
                                     <span class="nhsuk-u-visually-hidden">:</span>
                                     <span class="nhsuk-pagination__page">${nextGuidance.title}</span>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/minihub-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/minihub-main.ftl
@@ -3,7 +3,6 @@
 <@hst.defineObjects />
 <@hst.setBundle basename="uk.nhs.hee.web.global"/>
 
-<#-- @ftlvariable name="hstRequestContext" type="org.hippoecm.hst.core.request.HstRequestContext" -->
 <#-- @ftlvariable name="document" type="uk.nhs.hee.web.beans.MiniHub" -->
 <#-- @ftlvariable name="minihubName" type="java.lang.String" -->
 <#-- @ftlvariable name="currentGuidance" type="uk.nhs.hee.web.beans.Guidance" -->

--- a/site/components/src/main/java/uk/nhs/hee/web/components/MiniHubComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/MiniHubComponent.java
@@ -47,6 +47,9 @@ public class MiniHubComponent extends EssentialsDocumentComponent {
                 if (guidancePages.size() > 1) {
                     nextGuidance = guidancePages.get(1);
                 }
+
+                String minihubName = request.getRequestContext().getResolvedSiteMapItem().getHstSiteMapItem().getValue();
+                request.setModel("minihubName", minihubName);
             }
 
             request.setModel("previousGuidance", previousGuidance);


### PR DESCRIPTION
- Enhance the way to extract the next previous guidance URLs which support when the MiniHub put into the IA with nested URLS like https://production-hee.onehippo.io/site/knowledge-management/knowledge-management-toolkit