### PR TITLE
HEE-174: updated blogcategories value-list with (migrated) archived blog categories included

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/kls/blogcategories.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/kls/blogcategories.yaml
@@ -1,28 +1,2352 @@
 /content/documents/administration/valuelists/kls/blogcategories:
   jcr:primaryType: hippo:handle
   jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  jcr:uuid: 07ea54dc-5bbe-4ce9-a5a4-d59fe3181159
+  jcr:uuid: 8bb33041-01a1-4e1f-ba77-50d87b248106
   hippo:name: BlogCategories
   /blogcategories:
     jcr:primaryType: selection:valuelist
     jcr:mixinTypes: ['hippotranslation:translated', 'mix:referenceable']
-    jcr:uuid: a6bf4ce5-fbc4-43e2-a3a6-eb68c2810538
+    jcr:uuid: 51bf3402-e94b-47eb-8ebd-a1c846696125
     hippo:availability: [live, preview]
-    hippotranslation:id: 236c0d4f-6715-4a31-93e4-9a7f7646e557
+    hippotranslation:id: ec8799c9-6fa1-4268-866c-b38cf05e3493
     hippotranslation:locale: inherited - from query
     /selection:listitem[1]:
       jcr:primaryType: selection:listitem
-      selection:key: discovery_system
-      selection:label: Discovery System
+      selection:key: 2015-16
+      selection:label: 2015-16
     /selection:listitem[2]:
       jcr:primaryType: selection:listitem
-      selection:key: inter_library_loans
-      selection:label: Inter Library Loans
+      selection:key: '2019'
+      selection:label: '2019'
     /selection:listitem[3]:
       jcr:primaryType: selection:listitem
-      selection:key: data_serch
-      selection:label: Data Search
+      selection:key: '2020'
+      selection:label: '2020'
     /selection:listitem[4]:
+      jcr:primaryType: selection:listitem
+      selection:key: 5_4a
+      selection:label: 5.4a
+    /selection:listitem[5]:
+      jcr:primaryType: selection:listitem
+      selection:key: access
+      selection:label: Access
+    /selection:listitem[6]:
+      jcr:primaryType: selection:listitem
+      selection:key: access_to_lks
+      selection:label: Access to LKS
+    /selection:listitem[7]:
+      jcr:primaryType: selection:listitem
+      selection:key: action_learning_sets
+      selection:label: Action Learning Sets
+    /selection:listitem[8]:
+      jcr:primaryType: selection:listitem
+      selection:key: added_value
+      selection:label: added value
+    /selection:listitem[9]:
+      jcr:primaryType: selection:listitem
+      selection:key: advanced_competencies
+      selection:label: Advanced Competencies
+    /selection:listitem[10]:
+      jcr:primaryType: selection:listitem
+      selection:key: advocacy
+      selection:label: advocacy
+    /selection:listitem[11]:
+      jcr:primaryType: selection:listitem
+      selection:key: after_action_reviews
+      selection:label: After Action Reviews
+    /selection:listitem[12]:
+      jcr:primaryType: selection:listitem
+      selection:key: agenda
+      selection:label: Agenda
+    /selection:listitem[13]:
+      jcr:primaryType: selection:listitem
+      selection:key: ahsns
+      selection:label: AHSNs
+    /selection:listitem[14]:
+      jcr:primaryType: selection:listitem
+      selection:key: ai
+      selection:label: AI
+    /selection:listitem[15]:
+      jcr:primaryType: selection:listitem
+      selection:key: alerting
+      selection:label: alerting
+    /selection:listitem[16]:
+      jcr:primaryType: selection:listitem
+      selection:key: all-party_parliamentary_group_for_libraries
+      selection:label: All-Party Parliamentary Group for Libraries
+    /selection:listitem[17]:
+      jcr:primaryType: selection:listitem
+      selection:key: ambulance_services
+      selection:label: Ambulance Services
+    /selection:listitem[18]:
+      jcr:primaryType: selection:listitem
+      selection:key: amilliondecisions
+      selection:label: '#amilliondecisions'
+    /selection:listitem[19]:
+      jcr:primaryType: selection:listitem
+      selection:key: appg
+      selection:label: APPG
+    /selection:listitem[20]:
+      jcr:primaryType: selection:listitem
+      selection:key: apprenticeship_frameworks
+      selection:label: Apprenticeship Frameworks
+    /selection:listitem[21]:
+      jcr:primaryType: selection:listitem
+      selection:key: apprenticeship_standards
+      selection:label: Apprenticeship Standards
+    /selection:listitem[22]:
+      jcr:primaryType: selection:listitem
+      selection:key: apprenticeships
+      selection:label: Apprenticeships
+    /selection:listitem[23]:
+      jcr:primaryType: selection:listitem
+      selection:key: apps
+      selection:label: apps
+    /selection:listitem[24]:
+      jcr:primaryType: selection:listitem
+      selection:key: ara
+      selection:label: ARA
+    /selection:listitem[25]:
+      jcr:primaryType: selection:listitem
+      selection:key: artificial_intelligence
+      selection:label: Artificial Intelligence
+    /selection:listitem[26]:
+      jcr:primaryType: selection:listitem
+      selection:key: artificial_intelligence_ai
+      selection:label: Artificial Intelligence (AI)
+    /selection:listitem[27]:
+      jcr:primaryType: selection:listitem
+      selection:key: attitudes
+      selection:label: Attitudes
+    /selection:listitem[28]:
+      jcr:primaryType: selection:listitem
+      selection:key: audit
+      selection:label: audit
+    /selection:listitem[29]:
+      jcr:primaryType: selection:listitem
+      selection:key: authentication
+      selection:label: Authentication
+    /selection:listitem[30]:
+      jcr:primaryType: selection:listitem
+      selection:key: authentication_taf
+      selection:label: Authentication TaF
+    /selection:listitem[31]:
+      jcr:primaryType: selection:listitem
+      selection:key: automation
+      selection:label: automation
+    /selection:listitem[32]:
+      jcr:primaryType: selection:listitem
+      selection:key: bands_2-4
+      selection:label: Bands 2-4
+    /selection:listitem[33]:
+      jcr:primaryType: selection:listitem
+      selection:key: bands_5-6
+      selection:label: bands 5-6
+    /selection:listitem[34]:
+      jcr:primaryType: selection:listitem
+      selection:key: bands_7-8
+      selection:label: bands 7-8
+    /selection:listitem[35]:
+      jcr:primaryType: selection:listitem
+      selection:key: before_action_reviews
+      selection:label: Before Action Reviews
+    /selection:listitem[36]:
+      jcr:primaryType: selection:listitem
+      selection:key: behavioural
+      selection:label: Behavioural
+    /selection:listitem[37]:
+      jcr:primaryType: selection:listitem
+      selection:key: behaviours
+      selection:label: Behaviours
+    /selection:listitem[38]:
+      jcr:primaryType: selection:listitem
+      selection:key: benchmarking
+      selection:label: Benchmarking
+    /selection:listitem[39]:
+      jcr:primaryType: selection:listitem
+      selection:key: best_practice
+      selection:label: Best Practice
+    /selection:listitem[40]:
+      jcr:primaryType: selection:listitem
+      selection:key: bids
+      selection:label: Bids
+    /selection:listitem[41]:
+      jcr:primaryType: selection:listitem
+      selection:key: black_lives_matter
+      selection:label: black lives matter
+    /selection:listitem[42]:
+      jcr:primaryType: selection:listitem
+      selection:key: blended_learning
+      selection:label: Blended Learning
+    /selection:listitem[43]:
+      jcr:primaryType: selection:listitem
+      selection:key: blocked_websites
+      selection:label: Blocked Websites
+    /selection:listitem[44]:
+      jcr:primaryType: selection:listitem
+      selection:key: blog_posts
+      selection:label: blog posts
+    /selection:listitem[45]:
+      jcr:primaryType: selection:listitem
+      selection:key: blogging
+      selection:label: Blogging
+    /selection:listitem[46]:
+      jcr:primaryType: selection:listitem
+      selection:key: board_tool
+      selection:label: Board Tool
+    /selection:listitem[47]:
+      jcr:primaryType: selection:listitem
+      selection:key: briefing
+      selection:label: Briefing
+    /selection:listitem[48]:
+      jcr:primaryType: selection:listitem
+      selection:key: british_library
+      selection:label: British Library
+    /selection:listitem[49]:
+      jcr:primaryType: selection:listitem
+      selection:key: british_standard_iso_116202014_library_performance_indicators
+      selection:label: British Standard ISO 11620:2014 Library Performance Indicators
+    /selection:listitem[50]:
+      jcr:primaryType: selection:listitem
+      selection:key: bulletin
+      selection:label: Bulletin
+    /selection:listitem[51]:
+      jcr:primaryType: selection:listitem
+      selection:key: bulletins
+      selection:label: bulletins
+    /selection:listitem[52]:
+      jcr:primaryType: selection:listitem
+      selection:key: business_cases
+      selection:label: Business Cases
+    /selection:listitem[53]:
+      jcr:primaryType: selection:listitem
+      selection:key: campaign
+      selection:label: Campaign
+    /selection:listitem[54]:
+      jcr:primaryType: selection:listitem
+      selection:key: career_pathway
+      selection:label: Career Pathway
+    /selection:listitem[55]:
+      jcr:primaryType: selection:listitem
+      selection:key: career_vocational_skills
+      selection:label: Career/Vocational Skills
+    /selection:listitem[56]:
+      jcr:primaryType: selection:listitem
+      selection:key: careers
+      selection:label: Careers
+    /selection:listitem[57]:
+      jcr:primaryType: selection:listitem
+      selection:key: cas
+      selection:label: CAS
+    /selection:listitem[58]:
+      jcr:primaryType: selection:listitem
+      selection:key: case_studies
+      selection:label: case studies
+    /selection:listitem[59]:
+      jcr:primaryType: selection:listitem
+      selection:key: ccgs
+      selection:label: CCGs
+    /selection:listitem[60]:
+      jcr:primaryType: selection:listitem
+      selection:key: champions
+      selection:label: champions
+    /selection:listitem[61]:
+      jcr:primaryType: selection:listitem
+      selection:key: change
+      selection:label: Change
+    /selection:listitem[62]:
+      jcr:primaryType: selection:listitem
+      selection:key: change_makers
+      selection:label: Change Makers
+    /selection:listitem[63]:
+      jcr:primaryType: selection:listitem
+      selection:key: charges
+      selection:label: Charges
+    /selection:listitem[64]:
+      jcr:primaryType: selection:listitem
+      selection:key: charging
+      selection:label: Charging
+    /selection:listitem[65]:
+      jcr:primaryType: selection:listitem
+      selection:key: ciber_research
+      selection:label: CIBER Research
+    /selection:listitem[66]:
+      jcr:primaryType: selection:listitem
+      selection:key: cilip
+      selection:label: CILIP
+    /selection:listitem[67]:
+      jcr:primaryType: selection:listitem
+      selection:key: cilip_careers_hub
+      selection:label: CILIP Careers Hub
+    /selection:listitem[68]:
+      jcr:primaryType: selection:listitem
+      selection:key: cilip_code_of_conduct
+      selection:label: CILIP Code of Conduct
+    /selection:listitem[69]:
+      jcr:primaryType: selection:listitem
+      selection:key: cilip_pksb
+      selection:label: CILIP PKSB
+    /selection:listitem[70]:
+      jcr:primaryType: selection:listitem
+      selection:key: cilip_professional_registration
+      selection:label: CILIP Professional Registration
+    /selection:listitem[71]:
+      jcr:primaryType: selection:listitem
+      selection:key: cilip_special_interest_groups
+      selection:label: CILIP Special Interest Groups
+    /selection:listitem[72]:
+      jcr:primaryType: selection:listitem
+      selection:key: cilip_update
+      selection:label: CILIP Update
+    /selection:listitem[73]:
+      jcr:primaryType: selection:listitem
+      selection:key: cla
+      selection:label: CLA
+    /selection:listitem[74]:
+      jcr:primaryType: selection:listitem
+      selection:key: cla_licence
+      selection:label: CLA Licence
+    /selection:listitem[75]:
+      jcr:primaryType: selection:listitem
+      selection:key: cla_licence_plus_for_the_nhs
+      selection:label: CLA Licence Plus for the NHS
+    /selection:listitem[76]:
+      jcr:primaryType: selection:listitem
+      selection:key: clinical_librarian_services
+      selection:label: Clinical Librarian Services
+    /selection:listitem[77]:
+      jcr:primaryType: selection:listitem
+      selection:key: clinical_librarians
+      selection:label: Clinical Librarians
+    /selection:listitem[78]:
+      jcr:primaryType: selection:listitem
+      selection:key: clinical_networks
+      selection:label: Clinical Networks
+    /selection:listitem[79]:
+      jcr:primaryType: selection:listitem
+      selection:key: clinical_senates
+      selection:label: Clinical Senates
+    /selection:listitem[80]:
+      jcr:primaryType: selection:listitem
+      selection:key: closed_questions
+      selection:label: closed questions
+    /selection:listitem[81]:
+      jcr:primaryType: selection:listitem
+      selection:key: cognitive
+      selection:label: Cognitive
+    /selection:listitem[82]:
+      jcr:primaryType: selection:listitem
+      selection:key: collaborate_for_social_care
+      selection:label: Collaborate for Social Care
+    /selection:listitem[83]:
+      jcr:primaryType: selection:listitem
+      selection:key: collaboration
+      selection:label: Collaboration
+    /selection:listitem[84]:
+      jcr:primaryType: selection:listitem
+      selection:key: collaborative_procurement_taf
+      selection:label: Collaborative Procurement TaF
+    /selection:listitem[85]:
+      jcr:primaryType: selection:listitem
+      selection:key: collaborative_working
+      selection:label: collaborative working
+    /selection:listitem[86]:
+      jcr:primaryType: selection:listitem
+      selection:key: collective_purchasing
+      selection:label: Collective Purchasing
+    /selection:listitem[87]:
+      jcr:primaryType: selection:listitem
+      selection:key: commissioning
+      selection:label: Commissioning
+    /selection:listitem[88]:
+      jcr:primaryType: selection:listitem
+      selection:key: communication
+      selection:label: Communication
+    /selection:listitem[89]:
+      jcr:primaryType: selection:listitem
+      selection:key: competencies
+      selection:label: competencies
+    /selection:listitem[90]:
+      jcr:primaryType: selection:listitem
+      selection:key: competency_framework
+      selection:label: Competency Framework
+    /selection:listitem[91]:
+      jcr:primaryType: selection:listitem
+      selection:key: consolidation
+      selection:label: Consolidation
+    /selection:listitem[92]:
+      jcr:primaryType: selection:listitem
+      selection:key: consultation
+      selection:label: Consultation
+    /selection:listitem[93]:
+      jcr:primaryType: selection:listitem
+      selection:key: consultations
+      selection:label: consultations
+    /selection:listitem[94]:
+      jcr:primaryType: selection:listitem
+      selection:key: consumer_health_information
+      selection:label: Consumer Health Information
+    /selection:listitem[95]:
+      jcr:primaryType: selection:listitem
+      selection:key: consumer_health_websites
+      selection:label: Consumer Health Websites
+    /selection:listitem[96]:
+      jcr:primaryType: selection:listitem
+      selection:key: continuing_professional_development
+      selection:label: Continuing Professional Development
+    /selection:listitem[97]:
+      jcr:primaryType: selection:listitem
+      selection:key: conversational_leadership
+      selection:label: Conversational Leadership
+    /selection:listitem[98]:
+      jcr:primaryType: selection:listitem
+      selection:key: copyright
+      selection:label: copyright
+    /selection:listitem[99]:
+      jcr:primaryType: selection:listitem
+      selection:key: copyright_fee_paid
+      selection:label: Copyright Fee Paid
+    /selection:listitem[100]:
+      jcr:primaryType: selection:listitem
+      selection:key: copyright_first_responders
+      selection:label: Copyright First Responders
+    /selection:listitem[101]:
+      jcr:primaryType: selection:listitem
+      selection:key: core_competencies
+      selection:label: Core Competencies
+    /selection:listitem[102]:
+      jcr:primaryType: selection:listitem
+      selection:key: core_content
+      selection:label: Core Content
+    /selection:listitem[103]:
+      jcr:primaryType: selection:listitem
+      selection:key: core_service_offer
+      selection:label: Core Service Offer
+    /selection:listitem[104]:
+      jcr:primaryType: selection:listitem
+      selection:key: core_service_offer_taf
+      selection:label: Core Service Offer TaF
+    /selection:listitem[105]:
+      jcr:primaryType: selection:listitem
+      selection:key: cost_savings
+      selection:label: Cost Savings
+    /selection:listitem[106]:
+      jcr:primaryType: selection:listitem
+      selection:key: covid-19
+      selection:label: COVID-19
+    /selection:listitem[107]:
+      jcr:primaryType: selection:listitem
+      selection:key: cpd
+      selection:label: CPD
+    /selection:listitem[108]:
+      jcr:primaryType: selection:listitem
+      selection:key: csus
+      selection:label: CSUs
+    /selection:listitem[109]:
+      jcr:primaryType: selection:listitem
+      selection:key: cultural_hubs_arts_in_libraries_programme
+      selection:label: Cultural Hubs Arts in Libraries Programme
+    /selection:listitem[110]:
+      jcr:primaryType: selection:listitem
+      selection:key: current_awareness
+      selection:label: current awareness
+    /selection:listitem[111]:
+      jcr:primaryType: selection:listitem
+      selection:key: current_awareness_taf
+      selection:label: Current Awareness TaF
+    /selection:listitem[112]:
+      jcr:primaryType: selection:listitem
+      selection:key: current_awarness
+      selection:label: Current Awarness
+    /selection:listitem[113]:
+      jcr:primaryType: selection:listitem
+      selection:key: curriculum
+      selection:label: curriculum
+    /selection:listitem[114]:
+      jcr:primaryType: selection:listitem
+      selection:key: data_protection_act_dpa
+      selection:label: Data Protection Act (DPA)
+    /selection:listitem[115]:
+      jcr:primaryType: selection:listitem
+      selection:key: data_protection_officer_dpo
+      selection:label: Data Protection Officer (DPO)
+    /selection:listitem[116]:
+      jcr:primaryType: selection:listitem
+      selection:key: data_search
+      selection:label: Data Search
+    /selection:listitem[117]:
+      jcr:primaryType: selection:listitem
+      selection:key: databases
+      selection:label: Databases
+    /selection:listitem[118]:
+      jcr:primaryType: selection:listitem
+      selection:key: decision_making
+      selection:label: Decision Making
+    /selection:listitem[119]:
+      jcr:primaryType: selection:listitem
+      selection:key: defining_core_competencies
+      selection:label: Defining Core Competencies
+    /selection:listitem[120]:
+      jcr:primaryType: selection:listitem
+      selection:key: defining_core_competencies_taf
+      selection:label: Defining Core Competencies TaF
+    /selection:listitem[121]:
+      jcr:primaryType: selection:listitem
+      selection:key: development
+      selection:label: development
+    /selection:listitem[122]:
+      jcr:primaryType: selection:listitem
+      selection:key: development_needs
+      selection:label: Development Needs
+    /selection:listitem[123]:
+      jcr:primaryType: selection:listitem
+      selection:key: digital
+      selection:label: digital
+    /selection:listitem[124]:
+      jcr:primaryType: selection:listitem
+      selection:key: digital_champions
+      selection:label: digital champions
+    /selection:listitem[125]:
+      jcr:primaryType: selection:listitem
+      selection:key: digital_future
+      selection:label: Digital Future
+    /selection:listitem[126]:
+      jcr:primaryType: selection:listitem
+      selection:key: digital_literacy
+      selection:label: digital literacy
+    /selection:listitem[127]:
+      jcr:primaryType: selection:listitem
+      selection:key: directory
+      selection:label: directory
+    /selection:listitem[128]:
+      jcr:primaryType: selection:listitem
+      selection:key: discovery_system
+      selection:label: Discovery System
+    /selection:listitem[129]:
+      jcr:primaryType: selection:listitem
+      selection:key: discovery_tools
+      selection:label: Discovery Tools
+    /selection:listitem[130]:
+      jcr:primaryType: selection:listitem
+      selection:key: disruption
+      selection:label: disruption
+    /selection:listitem[131]:
+      jcr:primaryType: selection:listitem
+      selection:key: dna
+      selection:label: DNA
+    /selection:listitem[132]:
+      jcr:primaryType: selection:listitem
+      selection:key: document_delivery
+      selection:label: Document Delivery
+    /selection:listitem[133]:
       jcr:primaryType: selection:listitem
       selection:key: document_supply
       selection:label: Document Supply
+    /selection:listitem[134]:
+      jcr:primaryType: selection:listitem
+      selection:key: driver_diagram
+      selection:label: Driver Diagram
+    /selection:listitem[135]:
+      jcr:primaryType: selection:listitem
+      selection:key: e-books
+      selection:label: E-Books
+    /selection:listitem[136]:
+      jcr:primaryType: selection:listitem
+      selection:key: e-learning
+      selection:label: e-Learning
+    /selection:listitem[137]:
+      jcr:primaryType: selection:listitem
+      selection:key: e-resources
+      selection:label: E-resources
+    /selection:listitem[138]:
+      jcr:primaryType: selection:listitem
+      selection:key: eahil
+      selection:label: EAHIL
+    /selection:listitem[139]:
+      jcr:primaryType: selection:listitem
+      selection:key: early_adopters_pilot
+      selection:label: Early Adopters Pilot
+    /selection:listitem[140]:
+      jcr:primaryType: selection:listitem
+      selection:key: eblip4_conference
+      selection:label: EBLIP4 conference
+    /selection:listitem[141]:
+      jcr:primaryType: selection:listitem
+      selection:key: economic_benefit
+      selection:label: Economic Benefit
+    /selection:listitem[142]:
+      jcr:primaryType: selection:listitem
+      selection:key: effective_metrics
+      selection:label: Effective Metrics
+    /selection:listitem[143]:
+      jcr:primaryType: selection:listitem
+      selection:key: elearning_for_healthcare
+      selection:label: eLearning for Healthcare
+    /selection:listitem[144]:
+      jcr:primaryType: selection:listitem
+      selection:key: eligibility_matrix
+      selection:label: eligibility matrix
+    /selection:listitem[145]:
+      jcr:primaryType: selection:listitem
+      selection:key: emerging_technologies
+      selection:label: Emerging Technologies
+    /selection:listitem[146]:
+      jcr:primaryType: selection:listitem
+      selection:key: employer_engagement_events
+      selection:label: Employer Engagement Events
+    /selection:listitem[147]:
+      jcr:primaryType: selection:listitem
+      selection:key: end_users
+      selection:label: End Users
+    /selection:listitem[148]:
+      jcr:primaryType: selection:listitem
+      selection:key: engagement
+      selection:label: Engagement
+    /selection:listitem[149]:
+      jcr:primaryType: selection:listitem
+      selection:key: engaging_libraries_scheme
+      selection:label: Engaging Libraries Scheme
+    /selection:listitem[150]:
+      jcr:primaryType: selection:listitem
+      selection:key: enquiries
+      selection:label: enquiries
+    /selection:listitem[151]:
+      jcr:primaryType: selection:listitem
+      selection:key: equality
+      selection:label: equality
+    /selection:listitem[152]:
+      jcr:primaryType: selection:listitem
+      selection:key: equity
+      selection:label: equity
+    /selection:listitem[153]:
+      jcr:primaryType: selection:listitem
+      selection:key: espresso_caf
+      selection:label: Espresso Café
+    /selection:listitem[154]:
+      jcr:primaryType: selection:listitem
+      selection:key: ethnic_diversity
+      selection:label: Ethnic Diversity
+    /selection:listitem[155]:
+      jcr:primaryType: selection:listitem
+      selection:key: evaluation
+      selection:label: Evaluation
+    /selection:listitem[156]:
+      jcr:primaryType: selection:listitem
+      selection:key: evaluation_framework
+      selection:label: Evaluation Framework
+    /selection:listitem[157]:
+      jcr:primaryType: selection:listitem
+      selection:key: evidence
+      selection:label: Evidence
+    /selection:listitem[158]:
+      jcr:primaryType: selection:listitem
+      selection:key: evidence_and_knowledge_self_assessment_tool
+      selection:label: Evidence and Knowledge Self Assessment Tool
+    /selection:listitem[159]:
+      jcr:primaryType: selection:listitem
+      selection:key: evidence_based_practice
+      selection:label: Evidence Based Practice
+    /selection:listitem[160]:
+      jcr:primaryType: selection:listitem
+      selection:key: expenditure
+      selection:label: Expenditure
+    /selection:listitem[161]:
+      jcr:primaryType: selection:listitem
+      selection:key: expert_search
+      selection:label: Expert Search
+    /selection:listitem[162]:
+      jcr:primaryType: selection:listitem
+      selection:key: expert_searches
+      selection:label: expert searches
+    /selection:listitem[163]:
+      jcr:primaryType: selection:listitem
+      selection:key: expertise
+      selection:label: expertise
+    /selection:listitem[164]:
+      jcr:primaryType: selection:listitem
+      selection:key: facilitation
+      selection:label: facilitation
+    /selection:listitem[165]:
+      jcr:primaryType: selection:listitem
+      selection:key: factsheets
+      selection:label: Factsheets
+    /selection:listitem[166]:
+      jcr:primaryType: selection:listitem
+      selection:key: fake_news
+      selection:label: Fake News
+    /selection:listitem[167]:
+      jcr:primaryType: selection:listitem
+      selection:key: fining
+      selection:label: Fining
+    /selection:listitem[168]:
+      jcr:primaryType: selection:listitem
+      selection:key: fishbowl_method
+      selection:label: Fishbowl Method
+    /selection:listitem[169]:
+      jcr:primaryType: selection:listitem
+      selection:key: five_year_forward
+      selection:label: Five Year Forward
+    /selection:listitem[170]:
+      jcr:primaryType: selection:listitem
+      selection:key: flows_of_medicine
+      selection:label: Flows of Medicine
+    /selection:listitem[171]:
+      jcr:primaryType: selection:listitem
+      selection:key: focus_groups
+      selection:label: focus groups
+    /selection:listitem[172]:
+      jcr:primaryType: selection:listitem
+      selection:key: frontline
+      selection:label: Frontline
+    /selection:listitem[173]:
+      jcr:primaryType: selection:listitem
+      selection:key: functional
+      selection:label: Functional
+    /selection:listitem[174]:
+      jcr:primaryType: selection:listitem
+      selection:key: funding
+      selection:label: Funding
+    /selection:listitem[175]:
+      jcr:primaryType: selection:listitem
+      selection:key: funding_models
+      selection:label: funding models
+    /selection:listitem[176]:
+      jcr:primaryType: selection:listitem
+      selection:key: funding_taf
+      selection:label: Funding TaF
+    /selection:listitem[177]:
+      jcr:primaryType: selection:listitem
+      selection:key: future_developments
+      selection:label: Future Developments
+    /selection:listitem[178]:
+      jcr:primaryType: selection:listitem
+      selection:key: future_workforce_development
+      selection:label: Future Workforce Development
+    /selection:listitem[179]:
+      jcr:primaryType: selection:listitem
+      selection:key: gdpr
+      selection:label: GDPR
+    /selection:listitem[180]:
+      jcr:primaryType: selection:listitem
+      selection:key: gender_equality
+      selection:label: Gender Equality
+    /selection:listitem[181]:
+      jcr:primaryType: selection:listitem
+      selection:key: general
+      selection:label: General
+    /selection:listitem[182]:
+      jcr:primaryType: selection:listitem
+      selection:key: general_data_protection_regulation_gdpr
+      selection:label: General Data Protection Regulation (GDPR)
+    /selection:listitem[183]:
+      jcr:primaryType: selection:listitem
+      selection:key: general_data_protection_regulations
+      selection:label: General Data Protection Regulations
+    /selection:listitem[184]:
+      jcr:primaryType: selection:listitem
+      selection:key: generic_skills
+      selection:label: Generic Skills
+    /selection:listitem[185]:
+      jcr:primaryType: selection:listitem
+      selection:key: gift_of_time
+      selection:label: gift of time
+    /selection:listitem[186]:
+      jcr:primaryType: selection:listitem
+      selection:key: good_metrics
+      selection:label: Good metrics
+    /selection:listitem[187]:
+      jcr:primaryType: selection:listitem
+      selection:key: good_practice
+      selection:label: good practice
+    /selection:listitem[188]:
+      jcr:primaryType: selection:listitem
+      selection:key: guidance
+      selection:label: Guidance
+    /selection:listitem[189]:
+      jcr:primaryType: selection:listitem
+      selection:key: guidance_for_library_assistants
+      selection:label: Guidance for Library Assistants
+    /selection:listitem[190]:
+      jcr:primaryType: selection:listitem
+      selection:key: guidelines
+      selection:label: Guidelines
+    /selection:listitem[191]:
+      jcr:primaryType: selection:listitem
+      selection:key: hard-to-reach
+      selection:label: Hard-to-reach
+    /selection:listitem[192]:
+      jcr:primaryType: selection:listitem
+      selection:key: hclu
+      selection:label: HCLU
+    /selection:listitem[193]:
+      jcr:primaryType: selection:listitem
+      selection:key: hdas
+      selection:label: HDAS
+    /selection:listitem[194]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_and_wellbeing
+      selection:label: Health and Wellbeing
+    /selection:listitem[195]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_education_england
+      selection:label: Health Education England
+    /selection:listitem[196]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_information
+      selection:label: Health Information
+    /selection:listitem[197]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_information_and_libraries_journal_hilj
+      selection:label: Health Information and Libraries Journal (HILJ)
+    /selection:listitem[198]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_information_literacy
+      selection:label: Health Information Literacy
+    /selection:listitem[199]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_information_networks
+      selection:label: Health Information Networks
+    /selection:listitem[200]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_information_professionals
+      selection:label: Health Information Professionals
+    /selection:listitem[201]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_information_roadshow
+      selection:label: Health Information Roadshow
+    /selection:listitem[202]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_information_week
+      selection:label: Health Information Week
+    /selection:listitem[203]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_libraries
+      selection:label: Health Libraries
+    /selection:listitem[204]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_libraries_group
+      selection:label: Health Libraries Group
+    /selection:listitem[205]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_literacy
+      selection:label: Health Literacy
+    /selection:listitem[206]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_literacy_toolkit
+      selection:label: Health Literacy Toolkit
+    /selection:listitem[207]:
+      jcr:primaryType: selection:listitem
+      selection:key: healthcare
+      selection:label: Healthcare
+    /selection:listitem[208]:
+      jcr:primaryType: selection:listitem
+      selection:key: healthcare_databases
+      selection:label: Healthcare Databases
+    /selection:listitem[209]:
+      jcr:primaryType: selection:listitem
+      selection:key: healthcare_pksb
+      selection:label: Healthcare PKSB
+    /selection:listitem[210]:
+      jcr:primaryType: selection:listitem
+      selection:key: healthcare_workforce
+      selection:label: Healthcare Workforce
+    /selection:listitem[211]:
+      jcr:primaryType: selection:listitem
+      selection:key: healthwatch
+      selection:label: Healthwatch
+    /selection:listitem[212]:
+      jcr:primaryType: selection:listitem
+      selection:key: hee
+      selection:label: HEE
+    /selection:listitem[213]:
+      jcr:primaryType: selection:listitem
+      selection:key: hee_cilip_leadership_development_programme
+      selection:label: HEE/Cilip Leadership Development Programme
+    /selection:listitem[214]:
+      jcr:primaryType: selection:listitem
+      selection:key: hee_cilip_leadership_programme
+      selection:label: HEE/CILIP Leadership programme
+    /selection:listitem[215]:
+      jcr:primaryType: selection:listitem
+      selection:key: heelksl
+      selection:label: '#HEELKSL'
+    /selection:listitem[216]:
+      jcr:primaryType: selection:listitem
+      selection:key: high_quality_health_information
+      selection:label: High Quality Health Information
+    /selection:listitem[217]:
+      jcr:primaryType: selection:listitem
+      selection:key: hilj
+      selection:label: HILJ
+    /selection:listitem[218]:
+      jcr:primaryType: selection:listitem
+      selection:key: hiw2018
+      selection:label: '#HIW2018'
+    /selection:listitem[219]:
+      jcr:primaryType: selection:listitem
+      selection:key: hiw2019
+      selection:label: '#HIW2019'
+    /selection:listitem[220]:
+      jcr:primaryType: selection:listitem
+      selection:key: hiw2020
+      selection:label: '#HIW2020'
+    /selection:listitem[221]:
+      jcr:primaryType: selection:listitem
+      selection:key: hlg_conference
+      selection:label: HLG Conference
+    /selection:listitem[222]:
+      jcr:primaryType: selection:listitem
+      selection:key: hlisd
+      selection:label: HLISD
+    /selection:listitem[223]:
+      jcr:primaryType: selection:listitem
+      selection:key: hospices
+      selection:label: Hospices
+    /selection:listitem[224]:
+      jcr:primaryType: selection:listitem
+      selection:key: iclc_2017
+      selection:label: ICLC 2017
+    /selection:listitem[225]:
+      jcr:primaryType: selection:listitem
+      selection:key: icml
+      selection:label: ICML
+    /selection:listitem[226]:
+      jcr:primaryType: selection:listitem
+      selection:key: ics
+      selection:label: ICS
+    /selection:listitem[227]:
+      jcr:primaryType: selection:listitem
+      selection:key: ideas_bank
+      selection:label: Ideas Bank
+    /selection:listitem[228]:
+      jcr:primaryType: selection:listitem
+      selection:key: ideas_bank_for_health_libraries
+      selection:label: Ideas Bank for Health Libraries
+    /selection:listitem[229]:
+      jcr:primaryType: selection:listitem
+      selection:key: ills
+      selection:label: ILLs
+    /selection:listitem[230]:
+      jcr:primaryType: selection:listitem
+      selection:key: impact
+      selection:label: Impact
+    /selection:listitem[231]:
+      jcr:primaryType: selection:listitem
+      selection:key: impact_case_studies
+      selection:label: Impact Case Studies
+    /selection:listitem[232]:
+      jcr:primaryType: selection:listitem
+      selection:key: impact_case_study_vignettes
+      selection:label: impact case study vignettes
+    /selection:listitem[233]:
+      jcr:primaryType: selection:listitem
+      selection:key: impact_objectives
+      selection:label: Impact Objectives
+    /selection:listitem[234]:
+      jcr:primaryType: selection:listitem
+      selection:key: impact_questionnaire
+      selection:label: Impact Questionnaire
+    /selection:listitem[235]:
+      jcr:primaryType: selection:listitem
+      selection:key: impact_survey
+      selection:label: Impact Survey
+    /selection:listitem[236]:
+      jcr:primaryType: selection:listitem
+      selection:key: impact_toolkit
+      selection:label: Impact Toolkit
+    /selection:listitem[237]:
+      jcr:primaryType: selection:listitem
+      selection:key: implementation
+      selection:label: implementation
+    /selection:listitem[238]:
+      jcr:primaryType: selection:listitem
+      selection:key: inclusion
+      selection:label: inclusion
+    /selection:listitem[239]:
+      jcr:primaryType: selection:listitem
+      selection:key: income
+      selection:label: Income
+    /selection:listitem[240]:
+      jcr:primaryType: selection:listitem
+      selection:key: induction
+      selection:label: Induction
+    /selection:listitem[241]:
+      jcr:primaryType: selection:listitem
+      selection:key: inequalities
+      selection:label: inequalities
+    /selection:listitem[242]:
+      jcr:primaryType: selection:listitem
+      selection:key: influence
+      selection:label: Influence
+    /selection:listitem[243]:
+      jcr:primaryType: selection:listitem
+      selection:key: information
+      selection:label: Information
+    /selection:listitem[244]:
+      jcr:primaryType: selection:listitem
+      selection:key: information_consultancy
+      selection:label: information consultancy
+    /selection:listitem[245]:
+      jcr:primaryType: selection:listitem
+      selection:key: information_literacy
+      selection:label: Information Literacy
+    /selection:listitem[246]:
+      jcr:primaryType: selection:listitem
+      selection:key: information_management
+      selection:label: Information Management
+    /selection:listitem[247]:
+      jcr:primaryType: selection:listitem
+      selection:key: information_standard
+      selection:label: Information Standard
+    /selection:listitem[248]:
+      jcr:primaryType: selection:listitem
+      selection:key: innovation
+      selection:label: innovation
+    /selection:listitem[249]:
+      jcr:primaryType: selection:listitem
+      selection:key: innovations
+      selection:label: innovations
+    /selection:listitem[250]:
+      jcr:primaryType: selection:listitem
+      selection:key: inter_library_loans
+      selection:label: Inter Library Loans
+    /selection:listitem[251]:
+      jcr:primaryType: selection:listitem
+      selection:key: interlending
+      selection:label: Interlending
+    /selection:listitem[252]:
+      jcr:primaryType: selection:listitem
+      selection:key: interlending_and_document_supply
+      selection:label: interlending and document supply
+    /selection:listitem[253]:
+      jcr:primaryType: selection:listitem
+      selection:key: international_clinical_librarian_conference_2017
+      selection:label: International Clinical Librarian Conference 2017
+    /selection:listitem[254]:
+      jcr:primaryType: selection:listitem
+      selection:key: international_society_of_knowledge_organisation
+      selection:label: International Society of Knowledge Organisation
+    /selection:listitem[255]:
+      jcr:primaryType: selection:listitem
+      selection:key: interviews
+      selection:label: interviews
+    /selection:listitem[256]:
+      jcr:primaryType: selection:listitem
+      selection:key: isko
+      selection:label: ISKO
+    /selection:listitem[257]:
+      jcr:primaryType: selection:listitem
+      selection:key: it
+      selection:label: IT
+    /selection:listitem[258]:
+      jcr:primaryType: selection:listitem
+      selection:key: jisc
+      selection:label: JISC
+    /selection:listitem[259]:
+      jcr:primaryType: selection:listitem
+      selection:key: journals
+      selection:label: Journals
+    /selection:listitem[260]:
+      jcr:primaryType: selection:listitem
+      selection:key: key_performance_indicators
+      selection:label: Key Performance Indicators
+    /selection:listitem[261]:
+      jcr:primaryType: selection:listitem
+      selection:key: kfh
+      selection:label: KfH
+    /selection:listitem[262]:
+      jcr:primaryType: selection:listitem
+      selection:key: km
+      selection:label: KM
+    /selection:listitem[263]:
+      jcr:primaryType: selection:listitem
+      selection:key: km_community_of_practice
+      selection:label: KM Community of Practice
+    /selection:listitem[264]:
+      jcr:primaryType: selection:listitem
+      selection:key: km_pledges
+      selection:label: KM Pledges
+    /selection:listitem[265]:
+      jcr:primaryType: selection:listitem
+      selection:key: km_toolkit
+      selection:label: KM Toolkit
+    /selection:listitem[266]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge
+      selection:label: Knowledge
+    /selection:listitem[267]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge__and__information_management_special_interest_group_k_and_im
+      selection:label: Knowledge & Information Management Special Interest Group (K&IM)
+    /selection:listitem[268]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_cafe
+      selection:label: Knowledge Cafe
+    /selection:listitem[269]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_for_healthcare
+      selection:label: Knowledge for Healthcare
+    /selection:listitem[270]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_for_healthcare_leadership_development_programme
+      selection:label: Knowledge for Healthcare Leadership Development Programme
+    /selection:listitem[271]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_management
+      selection:label: knowledge management
+    /selection:listitem[272]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_management_taf
+      selection:label: Knowledge Management TaF
+    /selection:listitem[273]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_management_toolkit
+      selection:label: Knowledge Management Toolkit
+    /selection:listitem[274]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_mobilisation
+      selection:label: Knowledge Mobilisation
+    /selection:listitem[275]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_mobilisation_framework_programme
+      selection:label: Knowledge Mobilisation Framework programme
+    /selection:listitem[276]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_organisation
+      selection:label: Knowledge Organisation
+    /selection:listitem[277]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_sharing
+      selection:label: Knowledge Sharing
+    /selection:listitem[278]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledgeforelfcare
+      selection:label: Knowledgeforelfcare
+    /selection:listitem[279]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowvember
+      selection:label: '#knowvember'
+    /selection:listitem[280]:
+      jcr:primaryType: selection:listitem
+      selection:key: ko
+      selection:label: KO
+    /selection:listitem[281]:
+      jcr:primaryType: selection:listitem
+      selection:key: larkim
+      selection:label: LARKIM
+    /selection:listitem[282]:
+      jcr:primaryType: selection:listitem
+      selection:key: ldas
+      selection:label: LDAs
+    /selection:listitem[283]:
+      jcr:primaryType: selection:listitem
+      selection:key: leadership
+      selection:label: leadership
+    /selection:listitem[284]:
+      jcr:primaryType: selection:listitem
+      selection:key: leading_questions
+      selection:label: leading questions
+    /selection:listitem[285]:
+      jcr:primaryType: selection:listitem
+      selection:key: lean
+      selection:label: Lean
+    /selection:listitem[286]:
+      jcr:primaryType: selection:listitem
+      selection:key: lean_library
+      selection:label: Lean Library
+    /selection:listitem[287]:
+      jcr:primaryType: selection:listitem
+      selection:key: learning_lessons
+      selection:label: Learning Lessons
+    /selection:listitem[288]:
+      jcr:primaryType: selection:listitem
+      selection:key: learning_zone
+      selection:label: learning zone
+    /selection:listitem[289]:
+      jcr:primaryType: selection:listitem
+      selection:key: learning_zone_taf
+      selection:label: Learning Zone TaF
+    /selection:listitem[290]:
+      jcr:primaryType: selection:listitem
+      selection:key: legislation
+      selection:label: legislation
+    /selection:listitem[291]:
+      jcr:primaryType: selection:listitem
+      selection:key: lessons_learned
+      selection:label: lessons learned
+    /selection:listitem[292]:
+      jcr:primaryType: selection:listitem
+      selection:key: lessons_learned_bulletins
+      selection:label: lessons learned bulletins
+    /selection:listitem[293]:
+      jcr:primaryType: selection:listitem
+      selection:key: lessons_learnt
+      selection:label: Lessons Learnt
+    /selection:listitem[294]:
+      jcr:primaryType: selection:listitem
+      selection:key: letb
+      selection:label: LETB
+    /selection:listitem[295]:
+      jcr:primaryType: selection:listitem
+      selection:key: level_3
+      selection:label: Level 3
+    /selection:listitem[296]:
+      jcr:primaryType: selection:listitem
+      selection:key: library_and_knowledge_services
+      selection:label: library and knowledge services
+    /selection:listitem[297]:
+      jcr:primaryType: selection:listitem
+      selection:key: library_assistants
+      selection:label: Library Assistants
+    /selection:listitem[298]:
+      jcr:primaryType: selection:listitem
+      selection:key: library_management_system
+      selection:label: Library Management System
+    /selection:listitem[299]:
+      jcr:primaryType: selection:listitem
+      selection:key: lihnn
+      selection:label: LIHNN
+    /selection:listitem[300]:
+      jcr:primaryType: selection:listitem
+      selection:key: lihnnk_up
+      selection:label: LIHNNK Up
+    /selection:listitem[301]:
+      jcr:primaryType: selection:listitem
+      selection:key: lis_learning_providers
+      selection:label: LIS learning providers
+    /selection:listitem[302]:
+      jcr:primaryType: selection:listitem
+      selection:key: literature_searches
+      selection:label: Literature Searches
+    /selection:listitem[303]:
+      jcr:primaryType: selection:listitem
+      selection:key: literature_searching_modules
+      selection:label: Literature Searching Modules
+    /selection:listitem[304]:
+      jcr:primaryType: selection:listitem
+      selection:key: lks
+      selection:label: LKS
+    /selection:listitem[305]:
+      jcr:primaryType: selection:listitem
+      selection:key: lks_ase
+      selection:label: LKS ASE
+    /selection:listitem[306]:
+      jcr:primaryType: selection:listitem
+      selection:key: lks_evidence_base
+      selection:label: LKS Evidence Base
+    /selection:listitem[307]:
+      jcr:primaryType: selection:listitem
+      selection:key: lks_leadership_programme
+      selection:label: LKS Leadership Programme
+    /selection:listitem[308]:
+      jcr:primaryType: selection:listitem
+      selection:key: lksl_white_list
+      selection:label: LKSL White List
+    /selection:listitem[309]:
+      jcr:primaryType: selection:listitem
+      selection:key: lms
+      selection:label: LMS
+    /selection:listitem[310]:
+      jcr:primaryType: selection:listitem
+      selection:key: loans
+      selection:label: Loans
+    /selection:listitem[311]:
+      jcr:primaryType: selection:listitem
+      selection:key: local_authorities
+      selection:label: local authorities
+    /selection:listitem[312]:
+      jcr:primaryType: selection:listitem
+      selection:key: local_authority_public_health_teams
+      selection:label: Local Authority Public Health Teams
+    /selection:listitem[313]:
+      jcr:primaryType: selection:listitem
+      selection:key: lqaf
+      selection:label: LQAF
+    /selection:listitem[314]:
+      jcr:primaryType: selection:listitem
+      selection:key: machine_learning
+      selection:label: Machine Learning
+    /selection:listitem[315]:
+      jcr:primaryType: selection:listitem
+      selection:key: making_every_contact_count_mecc
+      selection:label: Making Every Contact Count (MECC)
+    /selection:listitem[316]:
+      jcr:primaryType: selection:listitem
+      selection:key: making_lks_business_critical
+      selection:label: Making LKS Business Critical
+    /selection:listitem[317]:
+      jcr:primaryType: selection:listitem
+      selection:key: map_toolkit
+      selection:label: MAP Toolkit
+    /selection:listitem[318]:
+      jcr:primaryType: selection:listitem
+      selection:key: mapping
+      selection:label: Mapping
+    /selection:listitem[319]:
+      jcr:primaryType: selection:listitem
+      selection:key: marketing
+      selection:label: marketing
+    /selection:listitem[320]:
+      jcr:primaryType: selection:listitem
+      selection:key: markgraf
+      selection:label: Markgraf
+    /selection:listitem[321]:
+      jcr:primaryType: selection:listitem
+      selection:key: memorandum_of_understanding
+      selection:label: Memorandum of Understanding
+    /selection:listitem[322]:
+      jcr:primaryType: selection:listitem
+      selection:key: mentors
+      selection:label: Mentors
+    /selection:listitem[323]:
+      jcr:primaryType: selection:listitem
+      selection:key: mergers
+      selection:label: Mergers
+    /selection:listitem[324]:
+      jcr:primaryType: selection:listitem
+      selection:key: metrics
+      selection:label: metrics
+    /selection:listitem[325]:
+      jcr:primaryType: selection:listitem
+      selection:key: metrics_for_success
+      selection:label: Metrics for Success
+    /selection:listitem[326]:
+      jcr:primaryType: selection:listitem
+      selection:key: metrics_taf
+      selection:label: Metrics TaF
+    /selection:listitem[327]:
+      jcr:primaryType: selection:listitem
+      selection:key: midlands
+      selection:label: Midlands
+    /selection:listitem[328]:
+      jcr:primaryType: selection:listitem
+      selection:key: million_decisions
+      selection:label: million decisions
+    /selection:listitem[329]:
+      jcr:primaryType: selection:listitem
+      selection:key: mobilising_evidence_and_knowledge
+      selection:label: Mobilising Evidence and Knowledge
+    /selection:listitem[330]:
+      jcr:primaryType: selection:listitem
+      selection:key: mobilising_knowledge
+      selection:label: mobilising knowledge
+    /selection:listitem[331]:
+      jcr:primaryType: selection:listitem
+      selection:key: models
+      selection:label: models
+    /selection:listitem[332]:
+      jcr:primaryType: selection:listitem
+      selection:key: mood-boosting_books
+      selection:label: Mood-boosting Books
+    /selection:listitem[333]:
+      jcr:primaryType: selection:listitem
+      selection:key: national_document_supply_scheme
+      selection:label: National Document Supply Scheme
+    /selection:listitem[334]:
+      jcr:primaryType: selection:listitem
+      selection:key: national_management_system
+      selection:label: National Management System
+    /selection:listitem[335]:
+      jcr:primaryType: selection:listitem
+      selection:key: national_policy
+      selection:label: National Policy
+    /selection:listitem[336]:
+      jcr:primaryType: selection:listitem
+      selection:key: national_training_programme
+      selection:label: National Training Programme
+    /selection:listitem[337]:
+      jcr:primaryType: selection:listitem
+      selection:key: national_training_programme_taf
+      selection:label: National Training Programme TaF
+    /selection:listitem[338]:
+      jcr:primaryType: selection:listitem
+      selection:key: national_union_list_of_journals
+      selection:label: National Union List of Journals
+    /selection:listitem[339]:
+      jcr:primaryType: selection:listitem
+      selection:key: national_workforce_mapping_study
+      selection:label: National Workforce Mapping Study
+    /selection:listitem[340]:
+      jcr:primaryType: selection:listitem
+      selection:key: natural_language_processing_nlp
+      selection:label: Natural Language Processing (NLP)
+    /selection:listitem[341]:
+      jcr:primaryType: selection:listitem
+      selection:key: networks
+      selection:label: Networks
+    /selection:listitem[342]:
+      jcr:primaryType: selection:listitem
+      selection:key: news
+      selection:label: News
+    /selection:listitem[343]:
+      jcr:primaryType: selection:listitem
+      selection:key: newsletter
+      selection:label: Newsletter
+    /selection:listitem[344]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs
+      selection:label: NHS
+    /selection:listitem[345]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs-higher_education_crossover_situations
+      selection:label: NHS-Higher Education crossover situations
+    /selection:listitem[346]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_academy_of_fabulous_stuff
+      selection:label: NHS Academy of Fabulous Stuff
+    /selection:listitem[347]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_ambulance_services_in_england
+      selection:label: NHS Ambulance Services in England
+    /selection:listitem[348]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_choices
+      selection:label: NHS Choices
+    /selection:listitem[349]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_constitution
+      selection:label: NHS constitution
+    /selection:listitem[350]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_england
+      selection:label: NHS England
+    /selection:listitem[351]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_england_learning_environment
+      selection:label: NHS England Learning Environment
+    /selection:listitem[352]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_information_technology
+      selection:label: NHS Information Technology
+    /selection:listitem[353]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_knowledge_mobilisation_framework_postcards
+      selection:label: NHS Knowledge Mobilisation Framework Postcards
+    /selection:listitem[354]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_leadership_academy
+      selection:label: NHS Leadership Academy
+    /selection:listitem[355]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_libraries_and_knowledge_services
+      selection:label: NHS Libraries and Knowledge Services
+    /selection:listitem[356]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_mandate
+      selection:label: NHS Mandate
+    /selection:listitem[357]:
+      jcr:primaryType: selection:listitem
+      selection:key: nhs_values
+      selection:label: NHS values
+    /selection:listitem[358]:
+      jcr:primaryType: selection:listitem
+      selection:key: nice
+      selection:label: NICE
+    /selection:listitem[359]:
+      jcr:primaryType: selection:listitem
+      selection:key: nick_poole
+      selection:label: Nick Poole
+    /selection:listitem[360]:
+      jcr:primaryType: selection:listitem
+      selection:key: nihr
+      selection:label: NIHR
+    /selection:listitem[361]:
+      jcr:primaryType: selection:listitem
+      selection:key: north
+      selection:label: North
+    /selection:listitem[362]:
+      jcr:primaryType: selection:listitem
+      selection:key: not-for-profit_sector_bodies
+      selection:label: not-for-profit sector bodies
+    /selection:listitem[363]:
+      jcr:primaryType: selection:listitem
+      selection:key: official_report
+      selection:label: official report
+    /selection:listitem[364]:
+      jcr:primaryType: selection:listitem
+      selection:key: online_resources
+      selection:label: online resources
+    /selection:listitem[365]:
+      jcr:primaryType: selection:listitem
+      selection:key: open_access
+      selection:label: open access
+    /selection:listitem[366]:
+      jcr:primaryType: selection:listitem
+      selection:key: open_access_taf
+      selection:label: Open Access TaF
+    /selection:listitem[367]:
+      jcr:primaryType: selection:listitem
+      selection:key: optimising_investment
+      selection:label: Optimising Investment
+    /selection:listitem[368]:
+      jcr:primaryType: selection:listitem
+      selection:key: outcomes
+      selection:label: Outcomes
+    /selection:listitem[369]:
+      jcr:primaryType: selection:listitem
+      selection:key: para-professional_posts
+      selection:label: para-professional posts
+    /selection:listitem[370]:
+      jcr:primaryType: selection:listitem
+      selection:key: paramedic_workforce
+      selection:label: Paramedic Workforce
+    /selection:listitem[371]:
+      jcr:primaryType: selection:listitem
+      selection:key: paraprofessional_staff
+      selection:label: Paraprofessional Staff
+    /selection:listitem[372]:
+      jcr:primaryType: selection:listitem
+      selection:key: partenerships
+      selection:label: Partenerships
+    /selection:listitem[373]:
+      jcr:primaryType: selection:listitem
+      selection:key: partnerships
+      selection:label: Partnerships
+    /selection:listitem[374]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient__and__public_information_ppi_ideas_bank
+      selection:label: Patient & Public Information (PPI) Ideas Bank
+    /selection:listitem[375]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient_and_public_information
+      selection:label: Patient and Public Information
+    /selection:listitem[376]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient_and_public_information_guidance
+      selection:label: Patient and Public Information Guidance
+    /selection:listitem[377]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient_and_public_information_taf
+      selection:label: Patient and Public Information TaF
+    /selection:listitem[378]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient_care
+      selection:label: Patient Care
+    /selection:listitem[379]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient_information_drivers
+      selection:label: Patient information drivers
+    /selection:listitem[380]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient_leaflets
+      selection:label: Patient Leaflets
+    /selection:listitem[381]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient_support_groups
+      selection:label: Patient Support Groups
+    /selection:listitem[382]:
+      jcr:primaryType: selection:listitem
+      selection:key: pay_per_view
+      selection:label: pay per view
+    /selection:listitem[383]:
+      jcr:primaryType: selection:listitem
+      selection:key: personal_development
+      selection:label: Personal Development
+    /selection:listitem[384]:
+      jcr:primaryType: selection:listitem
+      selection:key: personal_stories
+      selection:label: Personal Stories
+    /selection:listitem[385]:
+      jcr:primaryType: selection:listitem
+      selection:key: pilot
+      selection:label: Pilot
+    /selection:listitem[386]:
+      jcr:primaryType: selection:listitem
+      selection:key: pksb
+      selection:label: PKSB
+    /selection:listitem[387]:
+      jcr:primaryType: selection:listitem
+      selection:key: pksb_for_health
+      selection:label: PKSB for Health
+    /selection:listitem[388]:
+      jcr:primaryType: selection:listitem
+      selection:key: place-based_care
+      selection:label: Place-based Care
+    /selection:listitem[389]:
+      jcr:primaryType: selection:listitem
+      selection:key: plan
+      selection:label: Plan
+    /selection:listitem[390]:
+      jcr:primaryType: selection:listitem
+      selection:key: plan_on_a_page
+      selection:label: Plan on a Page
+    /selection:listitem[391]:
+      jcr:primaryType: selection:listitem
+      selection:key: plan_s
+      selection:label: Plan S
+    /selection:listitem[392]:
+      jcr:primaryType: selection:listitem
+      selection:key: policies
+      selection:label: Policies
+    /selection:listitem[393]:
+      jcr:primaryType: selection:listitem
+      selection:key: policy
+      selection:label: Policy
+    /selection:listitem[394]:
+      jcr:primaryType: selection:listitem
+      selection:key: politician
+      selection:label: politician
+    /selection:listitem[395]:
+      jcr:primaryType: selection:listitem
+      selection:key: powerful_questions
+      selection:label: powerful questions
+    /selection:listitem[396]:
+      jcr:primaryType: selection:listitem
+      selection:key: ppi_contacts_database
+      selection:label: PPI Contacts Database
+    /selection:listitem[397]:
+      jcr:primaryType: selection:listitem
+      selection:key: primary_care
+      selection:label: Primary Care
+    /selection:listitem[398]:
+      jcr:primaryType: selection:listitem
+      selection:key: prison_library
+      selection:label: Prison library
+    /selection:listitem[399]:
+      jcr:primaryType: selection:listitem
+      selection:key: privacy
+      selection:label: Privacy
+    /selection:listitem[400]:
+      jcr:primaryType: selection:listitem
+      selection:key: procedures
+      selection:label: Procedures
+    /selection:listitem[401]:
+      jcr:primaryType: selection:listitem
+      selection:key: procurement
+      selection:label: Procurement
+    /selection:listitem[402]:
+      jcr:primaryType: selection:listitem
+      selection:key: professional_attitudes
+      selection:label: Professional Attitudes
+    /selection:listitem[403]:
+      jcr:primaryType: selection:listitem
+      selection:key: professional_behaviours
+      selection:label: Professional Behaviours
+    /selection:listitem[404]:
+      jcr:primaryType: selection:listitem
+      selection:key: professional_ethics
+      selection:label: Professional Ethics
+    /selection:listitem[405]:
+      jcr:primaryType: selection:listitem
+      selection:key: professional_posts
+      selection:label: professional posts
+    /selection:listitem[406]:
+      jcr:primaryType: selection:listitem
+      selection:key: professional_registration
+      selection:label: Professional Registration
+    /selection:listitem[407]:
+      jcr:primaryType: selection:listitem
+      selection:key: professional_staff
+      selection:label: Professional Staff
+    /selection:listitem[408]:
+      jcr:primaryType: selection:listitem
+      selection:key: professional_values
+      selection:label: Professional Values
+    /selection:listitem[409]:
+      jcr:primaryType: selection:listitem
+      selection:key: professsional_staff
+      selection:label: professsional staff
+    /selection:listitem[410]:
+      jcr:primaryType: selection:listitem
+      selection:key: project_work
+      selection:label: Project Work
+    /selection:listitem[411]:
+      jcr:primaryType: selection:listitem
+      selection:key: promotion
+      selection:label: Promotion
+    /selection:listitem[412]:
+      jcr:primaryType: selection:listitem
+      selection:key: public_health
+      selection:label: Public Health
+    /selection:listitem[413]:
+      jcr:primaryType: selection:listitem
+      selection:key: public_health_england
+      selection:label: Public Health England
+    /selection:listitem[414]:
+      jcr:primaryType: selection:listitem
+      selection:key: public_health_staff
+      selection:label: Public Health Staff
+    /selection:listitem[415]:
+      jcr:primaryType: selection:listitem
+      selection:key: public_information_ppi_contacts_database
+      selection:label: Public Information (PPI) Contacts Database
+    /selection:listitem[416]:
+      jcr:primaryType: selection:listitem
+      selection:key: public_libraries
+      selection:label: public libraries
+    /selection:listitem[417]:
+      jcr:primaryType: selection:listitem
+      selection:key: publications
+      selection:label: publications
+    /selection:listitem[418]:
+      jcr:primaryType: selection:listitem
+      selection:key: publications_database
+      selection:label: Publications Database
+    /selection:listitem[419]:
+      jcr:primaryType: selection:listitem
+      selection:key: publicity
+      selection:label: Publicity
+    /selection:listitem[420]:
+      jcr:primaryType: selection:listitem
+      selection:key: qualifications
+      selection:label: qualifications
+    /selection:listitem[421]:
+      jcr:primaryType: selection:listitem
+      selection:key: quality
+      selection:label: Quality
+    /selection:listitem[422]:
+      jcr:primaryType: selection:listitem
+      selection:key: quality_and_impact
+      selection:label: Quality and Impact
+    /selection:listitem[423]:
+      jcr:primaryType: selection:listitem
+      selection:key: quality_and_improvement_outcomes
+      selection:label: Quality and Improvement Outcomes
+    /selection:listitem[424]:
+      jcr:primaryType: selection:listitem
+      selection:key: quality_improvement_outcomes_framework
+      selection:label: quality improvement outcomes framework
+    /selection:listitem[425]:
+      jcr:primaryType: selection:listitem
+      selection:key: quality_improvement_standards
+      selection:label: Quality Improvement Standards
+    /selection:listitem[426]:
+      jcr:primaryType: selection:listitem
+      selection:key: quick_and_easy_access_to_evidence
+      selection:label: Quick and Easy Access to Evidence
+    /selection:listitem[427]:
+      jcr:primaryType: selection:listitem
+      selection:key: quick_reads
+      selection:label: Quick Reads
+    /selection:listitem[428]:
+      jcr:primaryType: selection:listitem
+      selection:key: r_and_i_hub
+      selection:label: R&I hub
+    /selection:listitem[429]:
+      jcr:primaryType: selection:listitem
+      selection:key: randomised_coffee_trial_rct
+      selection:label: Randomised Coffee Trial (RCT)
+    /selection:listitem[430]:
+      jcr:primaryType: selection:listitem
+      selection:key: reading_friends
+      selection:label: Reading Friends
+    /selection:listitem[431]:
+      jcr:primaryType: selection:listitem
+      selection:key: reading_well
+      selection:label: Reading Well
+    /selection:listitem[432]:
+      jcr:primaryType: selection:listitem
+      selection:key: reading_well_books_on_prescription
+      selection:label: Reading Well Books on Prescription
+    /selection:listitem[433]:
+      jcr:primaryType: selection:listitem
+      selection:key: real_life_experience
+      selection:label: Real Life Experience
+    /selection:listitem[434]:
+      jcr:primaryType: selection:listitem
+      selection:key: recommendations
+      selection:label: recommendations
+    /selection:listitem[435]:
+      jcr:primaryType: selection:listitem
+      selection:key: recovery_colleges
+      selection:label: Recovery Colleges
+    /selection:listitem[436]:
+      jcr:primaryType: selection:listitem
+      selection:key: recruitment
+      selection:label: Recruitment
+    /selection:listitem[437]:
+      jcr:primaryType: selection:listitem
+      selection:key: reflections
+      selection:label: reflections
+    /selection:listitem[438]:
+      jcr:primaryType: selection:listitem
+      selection:key: refresh
+      selection:label: refresh
+    /selection:listitem[439]:
+      jcr:primaryType: selection:listitem
+      selection:key: reminiscence_boxes
+      selection:label: Reminiscence Boxes
+    /selection:listitem[440]:
+      jcr:primaryType: selection:listitem
+      selection:key: remote_working
+      selection:label: Remote Working
+    /selection:listitem[441]:
+      jcr:primaryType: selection:listitem
+      selection:key: reports
+      selection:label: reports
+    /selection:listitem[442]:
+      jcr:primaryType: selection:listitem
+      selection:key: repository
+      selection:label: repository
+    /selection:listitem[443]:
+      jcr:primaryType: selection:listitem
+      selection:key: research
+      selection:label: research
+    /selection:listitem[444]:
+      jcr:primaryType: selection:listitem
+      selection:key: research_committee
+      selection:label: Research Committee
+    /selection:listitem[445]:
+      jcr:primaryType: selection:listitem
+      selection:key: research_departement
+      selection:label: Research Departement
+    /selection:listitem[446]:
+      jcr:primaryType: selection:listitem
+      selection:key: research_skills
+      selection:label: Research Skills
+    /selection:listitem[447]:
+      jcr:primaryType: selection:listitem
+      selection:key: reserchers
+      selection:label: Reserchers
+    /selection:listitem[448]:
+      jcr:primaryType: selection:listitem
+      selection:key: resource_discovery
+      selection:label: Resource Discovery
+    /selection:listitem[449]:
+      jcr:primaryType: selection:listitem
+      selection:key: resource_discovery_infrastructure
+      selection:label: Resource discovery infrastructure
+    /selection:listitem[450]:
+      jcr:primaryType: selection:listitem
+      selection:key: resource_discovery_taf
+      selection:label: Resource Discovery TaF
+    /selection:listitem[451]:
+      jcr:primaryType: selection:listitem
+      selection:key: resources
+      selection:label: Resources
+    /selection:listitem[452]:
+      jcr:primaryType: selection:listitem
+      selection:key: retention
+      selection:label: Retention
+    /selection:listitem[453]:
+      jcr:primaryType: selection:listitem
+      selection:key: retrospect
+      selection:label: Retrospect
+    /selection:listitem[454]:
+      jcr:primaryType: selection:listitem
+      selection:key: review
+      selection:label: review
+    /selection:listitem[455]:
+      jcr:primaryType: selection:listitem
+      selection:key: richard_osborn
+      selection:label: Richard Osborn
+    /selection:listitem[456]:
+      jcr:primaryType: selection:listitem
+      selection:key: robotics
+      selection:label: Robotics
+    /selection:listitem[457]:
+      jcr:primaryType: selection:listitem
+      selection:key: robots
+      selection:label: robots
+    /selection:listitem[458]:
+      jcr:primaryType: selection:listitem
+      selection:key: role_redesign
+      selection:label: Role Redesign
+    /selection:listitem[459]:
+      jcr:primaryType: selection:listitem
+      selection:key: roles
+      selection:label: Roles
+    /selection:listitem[460]:
+      jcr:primaryType: selection:listitem
+      selection:key: roundtable
+      selection:label: roundtable
+    /selection:listitem[461]:
+      jcr:primaryType: selection:listitem
+      selection:key: royal_society_of_medicine
+      selection:label: Royal Society of Medicine
+    /selection:listitem[462]:
+      jcr:primaryType: selection:listitem
+      selection:key: rsa
+      selection:label: RSA
+    /selection:listitem[463]:
+      jcr:primaryType: selection:listitem
+      selection:key: rss_feeds
+      selection:label: RSS Feeds
+    /selection:listitem[464]:
+      jcr:primaryType: selection:listitem
+      selection:key: sally_hernando_innovation_awards
+      selection:label: Sally Hernando innovation awards
+    /selection:listitem[465]:
+      jcr:primaryType: selection:listitem
+      selection:key: sally_hernando_innovations
+      selection:label: Sally Hernando Innovations
+    /selection:listitem[466]:
+      jcr:primaryType: selection:listitem
+      selection:key: sash
+      selection:label: SASH+
+    /selection:listitem[467]:
+      jcr:primaryType: selection:listitem
+      selection:key: saving_money
+      selection:label: Saving Money
+    /selection:listitem[468]:
+      jcr:primaryType: selection:listitem
+      selection:key: scoping
+      selection:label: Scoping
+    /selection:listitem[469]:
+      jcr:primaryType: selection:listitem
+      selection:key: search_data
+      selection:label: search data
+    /selection:listitem[470]:
+      jcr:primaryType: selection:listitem
+      selection:key: search_skills
+      selection:label: Search Skills
+    /selection:listitem[471]:
+      jcr:primaryType: selection:listitem
+      selection:key: searching_skills
+      selection:label: Searching Skills
+    /selection:listitem[472]:
+      jcr:primaryType: selection:listitem
+      selection:key: secretary_of_state
+      selection:label: Secretary of State
+    /selection:listitem[473]:
+      jcr:primaryType: selection:listitem
+      selection:key: sector
+      selection:label: Sector
+    /selection:listitem[474]:
+      jcr:primaryType: selection:listitem
+      selection:key: senates
+      selection:label: Senates
+    /selection:listitem[475]:
+      jcr:primaryType: selection:listitem
+      selection:key: senior_leaders
+      selection:label: senior leaders
+    /selection:listitem[476]:
+      jcr:primaryType: selection:listitem
+      selection:key: senior_leadership_programme
+      selection:label: Senior leadership programme
+    /selection:listitem[477]:
+      jcr:primaryType: selection:listitem
+      selection:key: service_development
+      selection:label: Service Development
+    /selection:listitem[478]:
+      jcr:primaryType: selection:listitem
+      selection:key: service_improvement
+      selection:label: Service Improvement
+    /selection:listitem[479]:
+      jcr:primaryType: selection:listitem
+      selection:key: service_level_agreements
+      selection:label: service level agreements
+    /selection:listitem[480]:
+      jcr:primaryType: selection:listitem
+      selection:key: service_modification
+      selection:label: Service Modification
+    /selection:listitem[481]:
+      jcr:primaryType: selection:listitem
+      selection:key: service_redesign
+      selection:label: Service Redesign
+    /selection:listitem[482]:
+      jcr:primaryType: selection:listitem
+      selection:key: service_reviews
+      selection:label: service reviews
+    /selection:listitem[483]:
+      jcr:primaryType: selection:listitem
+      selection:key: service_specifications
+      selection:label: Service Specifications
+    /selection:listitem[484]:
+      jcr:primaryType: selection:listitem
+      selection:key: service_transformation
+      selection:label: Service Transformation
+    /selection:listitem[485]:
+      jcr:primaryType: selection:listitem
+      selection:key: service_transformation_e-learning_project_step
+      selection:label: Service Transformation E-Learning Project (STEP)
+    /selection:listitem[486]:
+      jcr:primaryType: selection:listitem
+      selection:key: sharepoint
+      selection:label: SharePoint
+    /selection:listitem[487]:
+      jcr:primaryType: selection:listitem
+      selection:key: sharing_innovations_project
+      selection:label: Sharing Innovations Project
+    /selection:listitem[488]:
+      jcr:primaryType: selection:listitem
+      selection:key: sharon_markless
+      selection:label: Sharon Markless
+    /selection:listitem[489]:
+      jcr:primaryType: selection:listitem
+      selection:key: skills
+      selection:label: Skills
+    /selection:listitem[490]:
+      jcr:primaryType: selection:listitem
+      selection:key: social_cards
+      selection:label: social cards
+    /selection:listitem[491]:
+      jcr:primaryType: selection:listitem
+      selection:key: social_care
+      selection:label: Social Care
+    /selection:listitem[492]:
+      jcr:primaryType: selection:listitem
+      selection:key: social_media
+      selection:label: Social Media
+    /selection:listitem[493]:
+      jcr:primaryType: selection:listitem
+      selection:key: software
+      selection:label: software
+    /selection:listitem[494]:
+      jcr:primaryType: selection:listitem
+      selection:key: soutron
+      selection:label: Soutron
+    /selection:listitem[495]:
+      jcr:primaryType: selection:listitem
+      selection:key: specialist_competencies
+      selection:label: Specialist Competencies
+    /selection:listitem[496]:
+      jcr:primaryType: selection:listitem
+      selection:key: specialist_technical_skills
+      selection:label: Specialist/Technical Skills
+    /selection:listitem[497]:
+      jcr:primaryType: selection:listitem
+      selection:key: st_helens_borough_council
+      selection:label: St Helens Borough Council
+    /selection:listitem[498]:
+      jcr:primaryType: selection:listitem
+      selection:key: staff_training
+      selection:label: Staff Training
+    /selection:listitem[499]:
+      jcr:primaryType: selection:listitem
+      selection:key: staffing
+      selection:label: Staffing
+    /selection:listitem[500]:
+      jcr:primaryType: selection:listitem
+      selection:key: stakeholders
+      selection:label: Stakeholders
+    /selection:listitem[501]:
+      jcr:primaryType: selection:listitem
+      selection:key: standardisation
+      selection:label: Standardisation
+    /selection:listitem[502]:
+      jcr:primaryType: selection:listitem
+      selection:key: standards
+      selection:label: standards
+    /selection:listitem[503]:
+      jcr:primaryType: selection:listitem
+      selection:key: star_wars
+      selection:label: Star Wars!
+    /selection:listitem[504]:
+      jcr:primaryType: selection:listitem
+      selection:key: statistics
+      selection:label: Statistics
+    /selection:listitem[505]:
+      jcr:primaryType: selection:listitem
+      selection:key: staycation
+      selection:label: Staycation
+    /selection:listitem[506]:
+      jcr:primaryType: selection:listitem
+      selection:key: steering_group
+      selection:label: Steering Group
+    /selection:listitem[507]:
+      jcr:primaryType: selection:listitem
+      selection:key: step
+      selection:label: STEP
+    /selection:listitem[508]:
+      jcr:primaryType: selection:listitem
+      selection:key: stock
+      selection:label: stock
+    /selection:listitem[509]:
+      jcr:primaryType: selection:listitem
+      selection:key: stp
+      selection:label: STP
+    /selection:listitem[510]:
+      jcr:primaryType: selection:listitem
+      selection:key: stps
+      selection:label: STPs
+    /selection:listitem[511]:
+      jcr:primaryType: selection:listitem
+      selection:key: streamlining
+      selection:label: Streamlining
+    /selection:listitem[512]:
+      jcr:primaryType: selection:listitem
+      selection:key: streamlining_taf
+      selection:label: Streamlining TaF
+    /selection:listitem[513]:
+      jcr:primaryType: selection:listitem
+      selection:key: students
+      selection:label: Students
+    /selection:listitem[514]:
+      jcr:primaryType: selection:listitem
+      selection:key: subscriptions
+      selection:label: subscriptions
+    /selection:listitem[515]:
+      jcr:primaryType: selection:listitem
+      selection:key: summarising
+      selection:label: summarising
+    /selection:listitem[516]:
+      jcr:primaryType: selection:listitem
+      selection:key: suppliers
+      selection:label: Suppliers
+    /selection:listitem[517]:
+      jcr:primaryType: selection:listitem
+      selection:key: survey
+      selection:label: survey
+    /selection:listitem[518]:
+      jcr:primaryType: selection:listitem
+      selection:key: sustainability
+      selection:label: Sustainability
+    /selection:listitem[519]:
+      jcr:primaryType: selection:listitem
+      selection:key: sustainability_and_transformation_plans
+      selection:label: Sustainability and Transformation Plans
+    /selection:listitem[520]:
+      jcr:primaryType: selection:listitem
+      selection:key: swims_network
+      selection:label: SWIMS Network
+    /selection:listitem[521]:
+      jcr:primaryType: selection:listitem
+      selection:key: synthesising
+      selection:label: synthesising
+    /selection:listitem[522]:
+      jcr:primaryType: selection:listitem
+      selection:key: systematic_review
+      selection:label: Systematic Review
+    /selection:listitem[523]:
+      jcr:primaryType: selection:listitem
+      selection:key: taf
+      selection:label: TaF
+    /selection:listitem[524]:
+      jcr:primaryType: selection:listitem
+      selection:key: tailoring_services
+      selection:label: Tailoring Services
+    /selection:listitem[525]:
+      jcr:primaryType: selection:listitem
+      selection:key: talent_management_toolkit
+      selection:label: talent management toolkit
+    /selection:listitem[526]:
+      jcr:primaryType: selection:listitem
+      selection:key: targets
+      selection:label: Targets
+    /selection:listitem[527]:
+      jcr:primaryType: selection:listitem
+      selection:key: team
+      selection:label: Team
+    /selection:listitem[528]:
+      jcr:primaryType: selection:listitem
+      selection:key: technology
+      selection:label: Technology
+    /selection:listitem[529]:
+      jcr:primaryType: selection:listitem
+      selection:key: template
+      selection:label: template
+    /selection:listitem[530]:
+      jcr:primaryType: selection:listitem
+      selection:key: templates
+      selection:label: templates
+    /selection:listitem[531]:
+      jcr:primaryType: selection:listitem
+      selection:key: terms_of_reference
+      selection:label: Terms of Reference
+    /selection:listitem[532]:
+      jcr:primaryType: selection:listitem
+      selection:key: the_medical_research_council
+      selection:label: The Medical Research Council
+    /selection:listitem[533]:
+      jcr:primaryType: selection:listitem
+      selection:key: the_reading_agency
+      selection:label: The Reading Agency
+    /selection:listitem[534]:
+      jcr:primaryType: selection:listitem
+      selection:key: the_society_of_chief_librarians
+      selection:label: The Society of Chief Librarians
+    /selection:listitem[535]:
+      jcr:primaryType: selection:listitem
+      selection:key: theory
+      selection:label: Theory
+    /selection:listitem[536]:
+      jcr:primaryType: selection:listitem
+      selection:key: therapeutic_book_group
+      selection:label: Therapeutic Book Group
+    /selection:listitem[537]:
+      jcr:primaryType: selection:listitem
+      selection:key: toolkit
+      selection:label: toolkit
+    /selection:listitem[538]:
+      jcr:primaryType: selection:listitem
+      selection:key: tools
+      selection:label: tools
+    /selection:listitem[539]:
+      jcr:primaryType: selection:listitem
+      selection:key: topol_review
+      selection:label: Topol Review
+    /selection:listitem[540]:
+      jcr:primaryType: selection:listitem
+      selection:key: trained_library_and_information_professionals
+      selection:label: Trained Library and Information Professionals
+    /selection:listitem[541]:
+      jcr:primaryType: selection:listitem
+      selection:key: training
+      selection:label: Training
+    /selection:listitem[542]:
+      jcr:primaryType: selection:listitem
+      selection:key: training_needs_survey
+      selection:label: training needs survey
+    /selection:listitem[543]:
+      jcr:primaryType: selection:listitem
+      selection:key: training_programme
+      selection:label: training programme
+    /selection:listitem[544]:
+      jcr:primaryType: selection:listitem
+      selection:key: transferable_skills
+      selection:label: Transferable Skills
+    /selection:listitem[545]:
+      jcr:primaryType: selection:listitem
+      selection:key: transformation
+      selection:label: Transformation
+    /selection:listitem[546]:
+      jcr:primaryType: selection:listitem
+      selection:key: transforming_services
+      selection:label: Transforming Services
+    /selection:listitem[547]:
+      jcr:primaryType: selection:listitem
+      selection:key: twitter
+      selection:label: Twitter
+    /selection:listitem[548]:
+      jcr:primaryType: selection:listitem
+      selection:key: twitter_chat
+      selection:label: Twitter chat
+    /selection:listitem[549]:
+      jcr:primaryType: selection:listitem
+      selection:key: ukmedlibs
+      selection:label: '#ukmedlibs'
+    /selection:listitem[550]:
+      jcr:primaryType: selection:listitem
+      selection:key: uncategorized
+      selection:label: Uncategorized
+    /selection:listitem[551]:
+      jcr:primaryType: selection:listitem
+      selection:key: union_catalogue
+      selection:label: union catalogue
+    /selection:listitem[552]:
+      jcr:primaryType: selection:listitem
+      selection:key: universal_health_offer
+      selection:label: Universal Health Offer
+    /selection:listitem[553]:
+      jcr:primaryType: selection:listitem
+      selection:key: us_medical_library_association_mla
+      selection:label: US Medical Library Association (MLA)
+    /selection:listitem[554]:
+      jcr:primaryType: selection:listitem
+      selection:key: useful_links
+      selection:label: Useful Links
+    /selection:listitem[555]:
+      jcr:primaryType: selection:listitem
+      selection:key: user_education
+      selection:label: User Education
+    /selection:listitem[556]:
+      jcr:primaryType: selection:listitem
+      selection:key: user_induction
+      selection:label: user induction
+    /selection:listitem[557]:
+      jcr:primaryType: selection:listitem
+      selection:key: users
+      selection:label: Users
+    /selection:listitem[558]:
+      jcr:primaryType: selection:listitem
+      selection:key: value
+      selection:label: Value
+    /selection:listitem[559]:
+      jcr:primaryType: selection:listitem
+      selection:key: value_and_impact
+      selection:label: value and impact
+    /selection:listitem[560]:
+      jcr:primaryType: selection:listitem
+      selection:key: value_and_impact_taf
+      selection:label: Value and Impact TaF
+    /selection:listitem[561]:
+      jcr:primaryType: selection:listitem
+      selection:key: value_of_lks
+      selection:label: Value of LKS
+    /selection:listitem[562]:
+      jcr:primaryType: selection:listitem
+      selection:key: value_proposition
+      selection:label: Value Proposition
+    /selection:listitem[563]:
+      jcr:primaryType: selection:listitem
+      selection:key: value_stream
+      selection:label: Value Stream
+    /selection:listitem[564]:
+      jcr:primaryType: selection:listitem
+      selection:key: values
+      selection:label: Values
+    /selection:listitem[565]:
+      jcr:primaryType: selection:listitem
+      selection:key: virtual_calendar
+      selection:label: Virtual Calendar
+    /selection:listitem[566]:
+      jcr:primaryType: selection:listitem
+      selection:key: virtual_library_and_knowledge_services
+      selection:label: Virtual Library and Knowledge Services
+    /selection:listitem[567]:
+      jcr:primaryType: selection:listitem
+      selection:key: virtual_reference_group
+      selection:label: Virtual Reference Group
+    /selection:listitem[568]:
+      jcr:primaryType: selection:listitem
+      selection:key: vocational_skills
+      selection:label: Vocational Skills
+    /selection:listitem[569]:
+      jcr:primaryType: selection:listitem
+      selection:key: wayfless_links
+      selection:label: Wayfless Links
+    /selection:listitem[570]:
+      jcr:primaryType: selection:listitem
+      selection:key: web_aggregator
+      selection:label: Web Aggregator
+    /selection:listitem[571]:
+      jcr:primaryType: selection:listitem
+      selection:key: webex
+      selection:label: WebEx
+    /selection:listitem[572]:
+      jcr:primaryType: selection:listitem
+      selection:key: welcome_trust
+      selection:label: Welcome Trust
+    /selection:listitem[573]:
+      jcr:primaryType: selection:listitem
+      selection:key: wider_healthcare_community
+      selection:label: Wider healthcare Community
+    /selection:listitem[574]:
+      jcr:primaryType: selection:listitem
+      selection:key: wider_nhs_workforce
+      selection:label: Wider NHS Workforce
+    /selection:listitem[575]:
+      jcr:primaryType: selection:listitem
+      selection:key: wider_nhs_workforce_taf
+      selection:label: Wider NHS Workforce TaF
+    /selection:listitem[576]:
+      jcr:primaryType: selection:listitem
+      selection:key: wider_workforce
+      selection:label: Wider Workforce
+    /selection:listitem[577]:
+      jcr:primaryType: selection:listitem
+      selection:key: wifi
+      selection:label: WiFi
+    /selection:listitem[578]:
+      jcr:primaryType: selection:listitem
+      selection:key: word_cloud
+      selection:label: word cloud
+    /selection:listitem[579]:
+      jcr:primaryType: selection:listitem
+      selection:key: workforce
+      selection:label: Workforce
+    /selection:listitem[580]:
+      jcr:primaryType: selection:listitem
+      selection:key: workforce_planning_and_development
+      selection:label: Workforce Planning and Development
+    /selection:listitem[581]:
+      jcr:primaryType: selection:listitem
+      selection:key: working_from_home
+      selection:label: Working from Home
+    /selection:listitem[582]:
+      jcr:primaryType: selection:listitem
+      selection:key: workshop_evaluation
+      selection:label: Workshop Evaluation
+    /selection:listitem[583]:
+      jcr:primaryType: selection:listitem
+      selection:key: workshops
+      selection:label: Workshops
+    /selection:listitem[584]:
+      jcr:primaryType: selection:listitem
+      selection:key: writing
+      selection:label: Writing
+    /selection:listitem[585]:
+      jcr:primaryType: selection:listitem
+      selection:key: yammer
+      selection:label: Yammer


### PR DESCRIPTION
This is to essentially to sync up project repo with latest blog categories (which was already migrated to brCloud env [upto Staging as of now] as part of archived blog post migration) to ensure that a future reload of `blogcategories` value-list doesn't wipes out migrated categories from env.