### PR TITLE
HEE-238: Update to render blogs listing by 'hee:publicationDate' field

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
@@ -143,7 +143,7 @@
         <li>
             <span class="app-search-results-category">${item.categories?map(category -> categoriesMap[category])?join(', ')}</span>
             <h3><a href="<@hst.link hippobean=item/>">${item.title}</a></h3>
-            <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.summary}</p>
+            <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.summary!}</p>
             <div class="nhsuk-review-date">
                 <p class="nhsuk-body-s">
                     <@fmt.message key="published_on.text"/> ${item.publicationDate.time?string['dd MMMM yyyy']}

--- a/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageComponent.java
@@ -11,7 +11,6 @@ import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.core.component.HstComponentException;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
-import org.hippoecm.repository.HippoStdPubWfNodeType;
 import org.onehippo.cms7.essentials.components.EssentialsDocumentComponent;
 import org.onehippo.cms7.essentials.components.paging.Pageable;
 import org.slf4j.Logger;
@@ -27,9 +26,9 @@ import java.util.List;
 public abstract class ListingPageComponent extends EssentialsDocumentComponent {
     private static final Logger LOGGER = LoggerFactory.getLogger(ListingPageComponent.class);
 
-    private final static String ASCENDING_SORT_ORDER = "asc";
-    private final static String DESCENDING_SORT_ORDER = "desc";
-    private final static String SORT_BY_DATE_QUERY_PARAM = "sortByDate";
+    private static final String ASCENDING_SORT_ORDER = "asc";
+    private static final String DESCENDING_SORT_ORDER = "desc";
+    private static final String SORT_BY_DATE_QUERY_PARAM = "sortByDate";
 
     @Override
     public void doBeforeRender(final HstRequest request, final HstResponse response) {
@@ -187,10 +186,13 @@ public abstract class ListingPageComponent extends EssentialsDocumentComponent {
             sortOrder = sortByDateQueryParamValues.get(0);
         }
 
+        final String sortByDateField =
+                ListingPageType.getByName(getListingPageModel(request).getListingPageType()).getSortByDateField();
+
         if (sortOrder.equals(ASCENDING_SORT_ORDER)) {
-            query.addOrderByAscending(HippoStdPubWfNodeType.HIPPOSTDPUBWF_LAST_MODIFIED_DATE);
+            query.addOrderByAscending(sortByDateField);
         } else {
-            query.addOrderByDescending(HippoStdPubWfNodeType.HIPPOSTDPUBWF_LAST_MODIFIED_DATE);
+            query.addOrderByDescending(sortByDateField);
         }
     }
 

--- a/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageType.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageType.java
@@ -1,9 +1,11 @@
 package uk.nhs.hee.web.components;
 
 import org.apache.commons.lang.StringUtils;
+import org.hippoecm.repository.HippoStdPubWfNodeType;
+import uk.nhs.hee.web.constants.HeeNodeType;
 
 /**
- * An enumeration of Listing Page Types and its document types & category value-list identifier.
+ * An enumeration of Listing Page Types and its document types, sort by date field & category value-list identifier.
  *
  * <p>Note that the listing types should be in sync
  * with the value-list {@code /content/documents/administration/valuelists/listingpagetypes}.</p>
@@ -13,31 +15,52 @@ public enum ListingPageType {
     /**
      * Blog Listing
      */
-    BLOG_LISTING("blog", new String[]{"hee:blogPost"}, "blogCategories"),
+    BLOG_LISTING(
+            "blog",
+            new String[]{"hee:blogPost"},
+            HeeNodeType.PUBLICATION_DATE,
+            "blogCategories"),
 
     /**
      * Bulletin Listing
      */
-    BULLETIN_LISTING("bulletin", new String[]{"hee:bulletin"}, "bulletinCategories"),
+    BULLETIN_LISTING(
+            "bulletin",
+            new String[]{"hee:bulletin"},
+            HippoStdPubWfNodeType.HIPPOSTDPUBWF_LAST_MODIFIED_DATE,
+            "bulletinCategories"),
 
     /**
      * Case Study Listing
      */
-    CASE_STUDY_LISTING("casestudy", new String[]{"hee:caseStudy"}, "caseStudyCategories"),
+    CASE_STUDY_LISTING(
+            "casestudy",
+            new String[]{"hee:caseStudy"},
+            HippoStdPubWfNodeType.HIPPOSTDPUBWF_LAST_MODIFIED_DATE,
+            "caseStudyCategories"),
 
     /**
      * Search Listing
      */
-    SEARCH_LISTING("search", new String[]{}, StringUtils.EMPTY),
+    SEARCH_LISTING(
+            "search",
+            new String[]{},
+            HippoStdPubWfNodeType.HIPPOSTDPUBWF_LAST_MODIFIED_DATE,
+            StringUtils.EMPTY),
 
     /**
      * Search Bank Listing
      */
-    SEARCH_BANK_LISTING("searchbank", new String[]{"hee:searchBank"}, "searchBankTopics");
+    SEARCH_BANK_LISTING(
+            "searchbank",
+            new String[]{"hee:searchBank"},
+            HippoStdPubWfNodeType.HIPPOSTDPUBWF_LAST_MODIFIED_DATE,
+            "searchBankTopics");
 
 
     private final String type;
     private final String[] documentTypes;
+    private final String sortByDateField;
     private final String categoryValueListIdentifier;
 
     /**
@@ -50,10 +73,12 @@ public enum ListingPageType {
     ListingPageType(
             final String type,
             final String[] documentTypes,
+            final String sortByDateField,
             final String categoryValueListIdentifier
     ) {
         this.type = type;
         this.documentTypes = documentTypes;
+        this.sortByDateField = sortByDateField;
         this.categoryValueListIdentifier = categoryValueListIdentifier;
     }
 
@@ -94,6 +119,15 @@ public enum ListingPageType {
      */
     public String[] getDocumentTypes() {
         return documentTypes;
+    }
+
+    /**
+     * Returns name of the field with which the results needs to be sorted.
+     *
+     * @return name of the field with which the results needs to be sorted.
+     */
+    public String getSortByDateField() {
+        return sortByDateField;
     }
 
     /**

--- a/site/components/src/main/java/uk/nhs/hee/web/constants/HeeNodeType.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/constants/HeeNodeType.java
@@ -3,4 +3,5 @@ package uk.nhs.hee.web.constants;
 public interface HeeNodeType {
     String HEE_NAMESPACE = "hee";
     String CATEGORIES = "hee:categories";
+    String PUBLICATION_DATE = "hee:publicationDate";
 }


### PR DESCRIPTION
Note that when blogs are being sorted on search page (/site/search), it would still use default document last modified date meta field `hippostdpubwf:lastModificationDate` as it is the potential common sort field for all document types.