### PR TITLE
HEE-248: Query string append revert for home page (/) to knowledge staff (/knowledge-staff) redirect

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls/hometoknowledgestaffredirect.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls/hometoknowledgestaffredirect.yaml
@@ -19,11 +19,11 @@
     urlrewriter:rule: "<rule>\r\n    <name>Home to Knowledge Staff Redirect for hosts\
       \ other than 'library.hee.nhs.uk'</name>\r\n    <condition name=\"host\" operator=\"\
       equal\">library.hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\n    <to type=\"\
-      permanent-redirect\" last=\"true\">/knowledge-staff?%{query-string}</to>\r\n</rule>\r\n\r\n\
+      permanent-redirect\" last=\"true\">/knowledge-staff</to>\r\n</rule>\r\n\r\n\
       <rule>\r\n    <name>Home to Knowledge Staff Redirect for 'library.hee.nhs.uk'\
       \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
       \n    <from>^/$</from>\r\n    <to type=\"permanent-redirect\" last=\"true\"\
-      >/site/knowledge-staff?%{query-string}</to>\r\n</rule>"
+      >/site/knowledge-staff</to>\r\n</rule>"
   /hometoknowledgestaffredirect[2]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
@@ -38,11 +38,11 @@
     urlrewriter:rule: "<rule>\r\n    <name>Home to Knowledge Staff Redirect for hosts\
       \ other than 'library.hee.nhs.uk'</name>\r\n    <condition name=\"host\" operator=\"\
       equal\">library.hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\n    <to type=\"\
-      permanent-redirect\" last=\"true\">/knowledge-staff?%{query-string}</to>\r\n</rule>\r\n\r\n\
+      permanent-redirect\" last=\"true\">/knowledge-staff</to>\r\n</rule>\r\n\r\n\
       <rule>\r\n    <name>Home to Knowledge Staff Redirect for 'library.hee.nhs.uk'\
       \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
       \n    <from>^/$</from>\r\n    <to type=\"permanent-redirect\" last=\"true\"\
-      >/site/knowledge-staff?%{query-string}</to>\r\n</rule>"
+      >/site/knowledge-staff</to>\r\n</rule>"
   /hometoknowledgestaffredirect[3]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable']
@@ -58,8 +58,8 @@
     urlrewriter:rule: "<rule>\r\n    <name>Home to Knowledge Staff Redirect for hosts\
       \ other than 'library.hee.nhs.uk'</name>\r\n    <condition name=\"host\" operator=\"\
       equal\">library.hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\n    <to type=\"\
-      permanent-redirect\" last=\"true\">/knowledge-staff?%{query-string}</to>\r\n</rule>\r\n\r\n\
+      permanent-redirect\" last=\"true\">/knowledge-staff</to>\r\n</rule>\r\n\r\n\
       <rule>\r\n    <name>Home to Knowledge Staff Redirect for 'library.hee.nhs.uk'\
       \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
       \n    <from>^/$</from>\r\n    <to type=\"permanent-redirect\" last=\"true\"\
-      >/site/knowledge-staff?%{query-string}</to>\r\n</rule>"
+      >/site/knowledge-staff</to>\r\n</rule>"


### PR DESCRIPTION
This revert is to ensure that the redirect doesn't add a trailing question mark. Also, this redirect isn't expected to carry any query strings as of now and need to revisited in the future if such a requirement comes up.