### PR TITLE
HEE-252: Fix to render MininHub Guidance pages with correct URLs

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/searchresults-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/searchresults-main.ftl
@@ -84,7 +84,7 @@
 
                         <#if pageable??>
                             <ul class="nhsuk-list nhsuk-list--border">
-                                <@searchListItem items=pageable.items/>
+                                <@searchListItem items=pageable.items miniHubGuidancePathToURLMap=miniHubGuidancePathToURLMap/>
                             </ul>
                             <#include "../../include/pagination-nhs.ftl">
                         </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
@@ -35,20 +35,26 @@
 </#macro>
 
 <#macro blogListItem items categoriesMap>
+    <@hst.link var="pageNotFoundURL" siteMapItemRefId="pagenotfound"/>
+
     <#list items as item>
-        <li>
-            <span class="app-search-results-category">${item.categories?map(category -> categoriesMap[category])?join(', ')}</span>
-            <h3><a href="<@hst.link hippobean=item/>">${item.title}</a></h3>
-            <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.summary!}</p>
-            <div class="nhsuk-review-date">
-                <p class="nhsuk-body-s">
-                    <@fmt.message key="published_on.text"/> ${item.publicationDate.time?string['dd MMMM yyyy']}
-                </p>
-                <p class="nhsuk-body-s">
-                    <@fmt.message key="by.text"/> ${item.author}
-                </p>
-            </div>
-        </li>
+        <@hst.link hippobean=item var="pageURL"/>
+
+        <#if pageURL != pageNotFoundURL>
+            <li>
+                <span class="app-search-results-category">${item.categories?map(category -> categoriesMap[category])?join(', ')}</span>
+                <h3><a href="${pageURL}">${item.title}</a></h3>
+                <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.summary!}</p>
+                <div class="nhsuk-review-date">
+                    <p class="nhsuk-body-s">
+                        <@fmt.message key="published_on.text"/> ${item.publicationDate.time?string['dd MMMM yyyy']}
+                    </p>
+                    <p class="nhsuk-body-s">
+                        <@fmt.message key="by.text"/> ${item.author}
+                    </p>
+                </div>
+            </li>
+        </#if>
     </#list>
 </#macro>
 
@@ -178,18 +184,29 @@
     </#list>
 </#macro>
 
-<#macro searchListItem items>
+<#macro searchListItem items miniHubGuidancePathToURLMap>
+    <@hst.link var="pageNotFoundURL" siteMapItemRefId="pagenotfound"/>
+
     <#list items as item>
-        <li>
-            <span class="app-search-results-category">${item.contentType}</span>
-            <h3><a href="<@hst.link hippobean=item/>">${item.title}</a></h3>
-            <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.summary!}</p>
-            <div class="nhsuk-review-date">
-                <p class="nhsuk-body-s">
-                    <@fmt.message key="published_on.text"/> ${item.publishedDate}
-                </p>
-            </div>
-        </li>
+        <@hst.link hippobean=item var="pageURL"/>
+
+        <#if pageURL != pageNotFoundURL || ('uk.nhs.hee.web.beans.Guidance' == item.getClass().getName() && miniHubGuidancePathToURLMap[item.path]??)>
+            <li>
+                <span class="app-search-results-category">${item.contentType}</span>
+
+                <#if 'uk.nhs.hee.web.beans.Guidance' == item.getClass().getName() && miniHubGuidancePathToURLMap[item.path]??>
+                    <#assign pageURL=miniHubGuidancePathToURLMap[item.path]/>
+                </#if>
+
+                <h3><a href="${pageURL}">${item.title}</a></h3>
+                <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.summary!}</p>
+                <div class="nhsuk-review-date">
+                    <p class="nhsuk-body-s">
+                        <@fmt.message key="published_on.text"/> ${item.publishedDate}
+                    </p>
+                </div>
+            </li>
+        </#if>
     </#list>
 </#macro>
 

--- a/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageComponent.java
@@ -1,6 +1,8 @@
 package uk.nhs.hee.web.components;
 
 import com.google.common.base.Strings;
+import org.apache.jackrabbit.JcrConstants;
+import org.hippoecm.hst.container.RequestContextProvider;
 import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.HstQueryResult;
 import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
@@ -8,6 +10,7 @@ import org.hippoecm.hst.content.beans.query.exceptions.FilterException;
 import org.hippoecm.hst.content.beans.query.exceptions.QueryException;
 import org.hippoecm.hst.content.beans.query.filter.Filter;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.content.beans.standard.HippoBeanIterator;
 import org.hippoecm.hst.core.component.HstComponentException;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
@@ -15,13 +18,12 @@ import org.onehippo.cms7.essentials.components.EssentialsDocumentComponent;
 import org.onehippo.cms7.essentials.components.paging.Pageable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.nhs.hee.web.beans.Guidance;
 import uk.nhs.hee.web.beans.ListingPage;
+import uk.nhs.hee.web.beans.MiniHub;
 import uk.nhs.hee.web.utils.HstUtils;
 
-import java.util.List;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.Collectors;
+import java.util.*;
 import java.util.stream.StreamSupport;
 
 /**
@@ -63,17 +65,56 @@ public abstract class ListingPageComponent extends EssentialsDocumentComponent {
 
         final HstQueryResult results = query.execute();
 
-        // Removes/filters out the documents whose page is not found.
-        // TODO: Find out if there is a way to accommodate this through query to improve performance
-        final List<HippoBean> resultsWithoutNonPageBeans = StreamSupport.stream(
+        final boolean hasGuidance = StreamSupport.stream(
                 Spliterators.spliteratorUnknownSize(results.getHippoBeans(), Spliterator.ORDERED), false)
-                .filter(hippoBean -> HstUtils.isPageFound(request.getRequestContext(), hippoBean))
-                .collect(Collectors.toList());
+                .anyMatch(bean -> "hee:guidance".equals(bean.getSingleProperty(JcrConstants.JCR_PRIMARYTYPE)));
+
+        if (hasGuidance) {
+            addMiniHubGuidances(request);
+        } else {
+            request.setModel("miniHubGuidancePathToURLMap", Collections.emptyMap());
+        }
 
         return getPageableFactory().createPageable(
-                resultsWithoutNonPageBeans,
-                getCurrentPage(request),
-                listingPage.getPageSize().intValue());
+                results.getHippoBeans(),
+                results.getTotalSize(),
+                listingPage.getPageSize().intValue(),
+                getCurrentPage(request));
+    }
+
+    /**
+     * Adds a map of all MiniHub Guidance document Paths and its URLs (available in the CMS) to the model.
+     *
+     * <p>This map would be used by search listing view/template in order to render URLs
+     * for MiniHub Guidance documents (which may not have a channel page on its own).</p>
+     *
+     * @param request the {@link HstRequest} instance.
+     * @throws QueryException thrown when an error occurs during execution of the query built.
+     */
+    private void addMiniHubGuidances(final HstRequest request) throws QueryException {
+        final Map<String, String> miniHubGuidancePathToURLMap = new HashMap<>();
+
+        final HstQuery query = HstQueryBuilder
+                .create(RequestContextProvider.get().getSiteContentBaseBean())
+                .ofTypes(MiniHub.class).build();
+        final HstQueryResult result = query.execute();
+        final HippoBeanIterator beanIterator = result.getHippoBeans();
+
+        while (beanIterator.hasNext()) {
+            final MiniHub miniHubBean = (MiniHub) beanIterator.next();
+            final List<Guidance> guidanceDocs = miniHubBean.getGuidancePages();
+
+            for (final Guidance guidanceDoc : guidanceDocs) {
+                miniHubGuidancePathToURLMap.put(
+                        guidanceDoc.getPath(),
+                        HstUtils.getURLByBean(
+                                request.getRequestContext(), miniHubBean, false) +
+                                "/" +
+                                guidanceDoc.getName());
+            }
+        }
+
+        request.setModel("miniHubGuidancePathToURLMap", miniHubGuidancePathToURLMap);
     }
 
     /**

--- a/site/components/src/main/java/uk/nhs/hee/web/utils/HstUtils.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/utils/HstUtils.java
@@ -44,16 +44,24 @@ public class HstUtils {
     }
 
     /**
-     * Returns {@code true} if the URL for the given {@code hippoBean} is found.
-     * Otherwise, returns {@code false}.
+     * Returns URL for the given {@code hippoBean} instance.
      *
      * @param requestContext the {@link HstRequestContext} instance.
-     * @param hippoBean      the {@link HippoBean} instance.
-     * @return {@code true} if the URL for the given {@code hippoBean} is found.
-     * Otherwise, returns {@code false}.
+     * @param hippoBean      the {@link HippoBean} instance whose URL needs to be returned.
+     * @param fullQualified  Boolean indicating whether to return fully qualified URL or not.
+     * @return the URL for the given {@code hippoBean} instance.
      */
-    public static boolean isPageFound(final HstRequestContext requestContext, final HippoBean hippoBean) {
-        return !requestContext.getHstLinkCreator().create(hippoBean, requestContext).isNotFound();
+    public static String getURLByBean(
+            final HstRequestContext requestContext,
+            final HippoBean hippoBean,
+            final boolean fullQualified) {
+        final HstLink hstLink = requestContext.getHstLinkCreator().create(hippoBean, requestContext);
+
+        if (hstLink == null) {
+            return StringUtils.EMPTY;
+        }
+
+        return hstLink.toUrlForm(requestContext, fullQualified);
     }
 
 }


### PR DESCRIPTION
- Reverting changes made as part of the PR https://githubcom/Manifesto-Digital/hee-cms-platform/pull/79.
- Updated listing view/template to render documents only if it resolves to a channel page i.e. when the generated URL is not `/pagenotfound` (unless it's a MiniHub Guidance page). Note that this will leave the listing to display fewer results than what's set for `Page Size` in the corresponding ListingPage. In order to avoid this situation, Editors should be advised to not to publish documents which aren't ready to be added to the channel yet (unless it's a MiniHub Guidance document).
- Implemented a fix to render MiniHub Guidance pages with correct URLs.