### PR TITLE
HEE-271: SearchBank CMS fields alignment with migration data

### DIFF
--- a/repository-data/application/src/main/resources/hcm-actions.yaml
+++ b/repository-data/application/src/main/resources/hcm-actions.yaml
@@ -14,3 +14,6 @@ action-lists:
       /content/urlrewriter/kls/searchtosearchresultsredirect: reload
   - 1.0.16:
       /content/documents/administration/labels/listing: reload
+  - 1.0.17:
+      /content/documents/administration/labels/listing: reload
+      /content/documents/administration/valuelists/kls/searchbanktopics: reload

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/searchBank.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/searchBank.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: 42402c2d-ce0b-4b76-a4db-1c4e7a98260b
+          jcr:uuid: 067cf0f8-bd81-4471-93cb-c034588e7670
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -23,24 +23,6 @@ definitions:
             hipposysedit:path: hee:title
             hipposysedit:primary: false
             hipposysedit:type: String
-            hipposysedit:validators: [required]
-          /description:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: hee:description
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators: [required]
-          /details:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: hee:details
-            hipposysedit:primary: false
-            hipposysedit:type: Text
             hipposysedit:validators: [required]
           /strategies:
             jcr:primaryType: hipposysedit:field
@@ -69,6 +51,15 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: hippo:resource
             hipposysedit:validators: [optional]
+          /topics:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:topics
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators: [required]
           /provider:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -76,17 +67,15 @@ definitions:
             hipposysedit:ordered: false
             hipposysedit:path: hee:provider
             hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators: [optional]
-          /categories:
+            hipposysedit:type: DynamicDropdown
+          /keyTerms:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
             hipposysedit:multiple: true
             hipposysedit:ordered: false
-            hipposysedit:path: hee:categories
+            hipposysedit:path: hee:keyterms
             hipposysedit:primary: false
             hipposysedit:type: String
-            hipposysedit:validators: [required]
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
@@ -99,14 +88,14 @@ definitions:
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes: ['mix:referenceable']
           hee:title: ''
-          hee:description: ''
-          hee:details: ''
-          hee:provider: ''
-          jcr:uuid: 79a225d7-fe19-4286-aa54-6fa5e7b595a0
+          jcr:uuid: f5678485-22e4-468b-b153-11cb10960871
           hippostdpubwf:lastModificationDate: 2021-05-10T09:26:01.512+01:00
           hippostdpubwf:creationDate: 2021-05-10T09:26:01.513+01:00
           hee:categories: []
           hee:completedDate: 0001-01-01T12:00:00Z
+          hee:topics: []
+          hee:provider: ''
+          hee:keyterms: []
           /hee:strategyDocument:
             jcr:primaryType: hippo:resource
             hippo:filename: hippo:resource
@@ -144,18 +133,10 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-          /description:
-            jcr:primaryType: frontend:plugin
-            caption: Description
-            field: description
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /categories:
+          /topics:
             jcr:primaryType: frontend:plugin
             caption: Topics
-            field: categories
+            field: topics
             multiselect.type: palette
             palette.alloworder: true
             palette.maxrows: '10'
@@ -166,14 +147,20 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               source: /content/documents/administration/valuelists/kls/searchbanktopics
-          /details:
+          /keyTerms:
             jcr:primaryType: frontend:plugin
-            caption: Details
-            field: details
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            caption: Key Terms
+            field: keyTerms
+            multiselect.type: palette
+            palette.alloworder: true
+            palette.maxrows: '10'
+            plugin.class: org.onehippo.forge.selection.frontend.plugin.DynamicMultiSelectPlugin
+            selectlist.maxrows: '10'
+            valuelist.provider: service.valuelist.default
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              source: /content/documents/administration/valuelists/kls/searchbankkeyterms
           /strategyDocument:
             jcr:primaryType: frontend:plugin
             caption: String / Strategies Document
@@ -205,8 +192,10 @@ definitions:
             jcr:primaryType: frontend:plugin
             caption: Provider
             field: provider
-            hint: ''
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
+            hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              orientation: vertical
+              source: /content/documents/administration/valuelists/kls/searchbankproviders

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/labels/listing.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/labels/listing.yaml
@@ -3,7 +3,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: 03cc6eaf-ca38-4874-a8a5-22ae5ea2c643
   hippo:name: Listing
-  hippo:versionHistory: 53345eec-9103-4a87-95b9-849c27b9455a
+  hippo:versionHistory: 7b46b974-acb8-4454-bc7b-7a16fcd0d3de
   /listing[1]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -13,7 +13,7 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-24T17:37:06.731Z
-    hippostdpubwf:lastModificationDate: 2021-06-10T16:36:54.785+01:00
+    hippostdpubwf:lastModificationDate: 2021-06-15T11:51:14.850+01:00
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: [Used in a Bulletin component to show a bulletin
         item overview., Used in a Bulletin component to show a bulletin item website.,
@@ -23,16 +23,16 @@
     resourcebundle:keys: [bulletin.overview, bulletin.website, sort.label, sort.option.oldest,
       sort.option.newest, filter.category.label, filters.label, filter.content_type.label,
       filter.date.label, results.count.text, published_on.text, by.text, casestudy.sector,
-      casestudy.region, filter.topic.label, searchbank.topics, searchbank.details,
-      searchbank.strategies, searchbank.get_strategy, searchbank.search, searchbank.get_search,
-      searchbank.completed_on, searchbank.provider, category.text, casestudy.document,
-      searchbank.get_document, filter.year.label, event.date, event.location, casestudy.impact_group,
-      casestudy.impact_types]
+      casestudy.region, filter.topic.label, searchbank.topics, searchbank.strategies,
+      searchbank.get_strategy, searchbank.search, searchbank.get_search, searchbank.completed_on,
+      searchbank.provider, category.text, casestudy.document, searchbank.get_document,
+      filter.year.label, event.date, event.location, casestudy.impact_group, casestudy.impact_types,
+      searchbank.key_terms]
     resourcebundle:messages: [Overview, Website, Sort by date, Oldest, Newest, Category,
       Filters, Content type, Date, results, Published on, By, Sector, Region, Topic,
-      Topics, Details, Strings / Strategies, Get Strategy, Search, Get Search, Completed
-        on, Provider, Category, Document, Get Document, Year, Date, Location, Group
-        Impacted, Impact Types]
+      Topics, Strings / Strategies, Get Strategy, Search, Get Search, Completed on,
+      Provider, Category, Document, Get Document, Year, Date, Location, Group Impacted,
+      Impact Types, Key Terms]
   /listing[2]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
@@ -42,7 +42,7 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-24T17:37:06.731Z
-    hippostdpubwf:lastModificationDate: 2021-06-10T16:37:05.998+01:00
+    hippostdpubwf:lastModificationDate: 2021-06-15T11:51:51.927+01:00
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: [Used in a Bulletin component to show a bulletin
         item overview., Used in a Bulletin component to show a bulletin item website.,
@@ -52,16 +52,16 @@
     resourcebundle:keys: [bulletin.overview, bulletin.website, sort.label, sort.option.oldest,
       sort.option.newest, filter.category.label, filters.label, filter.content_type.label,
       filter.date.label, results.count.text, published_on.text, by.text, casestudy.sector,
-      casestudy.region, filter.topic.label, searchbank.topics, searchbank.details,
-      searchbank.strategies, searchbank.get_strategy, searchbank.search, searchbank.get_search,
-      searchbank.completed_on, searchbank.provider, category.text, casestudy.document,
-      searchbank.get_document, filter.year.label, event.date, event.location, casestudy.impact_group,
-      casestudy.impact_types]
+      casestudy.region, filter.topic.label, searchbank.topics, searchbank.strategies,
+      searchbank.get_strategy, searchbank.search, searchbank.get_search, searchbank.completed_on,
+      searchbank.provider, category.text, casestudy.document, searchbank.get_document,
+      filter.year.label, event.date, event.location, casestudy.impact_group, casestudy.impact_types,
+      searchbank.key_terms]
     resourcebundle:messages: [Overview, Website, Sort by date, Oldest, Newest, Category,
       Filters, Content type, Date, results, Published on, By, Sector, Region, Topic,
-      Topics, Details, Strings / Strategies, Get Strategy, Search, Get Search, Completed
-        on, Provider, Category, Document, Get Document, Year, Date, Location, Group
-        Impacted, Impact Types]
+      Topics, Strings / Strategies, Get Strategy, Search, Get Search, Completed on,
+      Provider, Category, Document, Get Document, Year, Date, Location, Group Impacted,
+      Impact Types, Key Terms]
   /listing[3]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -71,9 +71,9 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-24T17:37:06.731Z
-    hippostdpubwf:lastModificationDate: 2021-06-10T16:37:05.998+01:00
+    hippostdpubwf:lastModificationDate: 2021-06-15T11:51:51.927+01:00
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2021-06-10T16:37:07.690+01:00
+    hippostdpubwf:publicationDate: 2021-06-15T11:51:53.701+01:00
     resourcebundle:descriptions: [Used in a Bulletin component to show a bulletin
         item overview., Used in a Bulletin component to show a bulletin item website.,
       '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
@@ -82,13 +82,13 @@
     resourcebundle:keys: [bulletin.overview, bulletin.website, sort.label, sort.option.oldest,
       sort.option.newest, filter.category.label, filters.label, filter.content_type.label,
       filter.date.label, results.count.text, published_on.text, by.text, casestudy.sector,
-      casestudy.region, filter.topic.label, searchbank.topics, searchbank.details,
-      searchbank.strategies, searchbank.get_strategy, searchbank.search, searchbank.get_search,
-      searchbank.completed_on, searchbank.provider, category.text, casestudy.document,
-      searchbank.get_document, filter.year.label, event.date, event.location, casestudy.impact_group,
-      casestudy.impact_types]
+      casestudy.region, filter.topic.label, searchbank.topics, searchbank.strategies,
+      searchbank.get_strategy, searchbank.search, searchbank.get_search, searchbank.completed_on,
+      searchbank.provider, category.text, casestudy.document, searchbank.get_document,
+      filter.year.label, event.date, event.location, casestudy.impact_group, casestudy.impact_types,
+      searchbank.key_terms]
     resourcebundle:messages: [Overview, Website, Sort by date, Oldest, Newest, Category,
       Filters, Content type, Date, results, Published on, By, Sector, Region, Topic,
-      Topics, Details, Strings / Strategies, Get Strategy, Search, Get Search, Completed
-        on, Provider, Category, Document, Get Document, Year, Date, Location, Group
-        Impacted, Impact Types]
+      Topics, Strings / Strategies, Get Strategy, Search, Get Search, Completed on,
+      Provider, Category, Document, Get Document, Year, Date, Location, Group Impacted,
+      Impact Types, Key Terms]

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/kls/searchbankkeyterms.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/kls/searchbankkeyterms.yaml
@@ -1,0 +1,20 @@
+/content/documents/administration/valuelists/kls/searchbankkeyterms:
+  jcr:primaryType: hippo:handle
+  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
+  jcr:uuid: fdc7f222-01fc-447d-b704-c6c3d87bf3e5
+  hippo:name: SearchBankKeyTerms
+  /searchbankkeyterms:
+    jcr:primaryType: selection:valuelist
+    jcr:mixinTypes: ['hippotranslation:translated', 'mix:referenceable']
+    jcr:uuid: e931080b-e0b9-4bfa-9262-660a2db8c2da
+    hippo:availability: [live, preview]
+    hippotranslation:id: 242c8581-1695-48af-8f25-c2da070fd08e
+    hippotranslation:locale: inherited - from query
+    /selection:listitem[1]:
+      jcr:primaryType: selection:listitem
+      selection:key: environmental_microbiology
+      selection:label: ENVIRONMENTAL MICROBIOLOGY
+    /selection:listitem[2]:
+      jcr:primaryType: selection:listitem
+      selection:key: medical_records
+      selection:label: MEDICAL RECORDS

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/kls/searchbankproviders.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/kls/searchbankproviders.yaml
@@ -1,0 +1,361 @@
+/content/documents/administration/valuelists/kls/searchbankproviders:
+  jcr:primaryType: hippo:handle
+  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
+  jcr:uuid: cbf7aeef-8a62-4dce-94a6-69f455179392
+  hippo:name: SearchBankProviders
+  /searchbankproviders:
+    jcr:primaryType: selection:valuelist
+    jcr:mixinTypes: ['hippotranslation:translated', 'mix:referenceable']
+    jcr:uuid: 6fa0e2f3-47ff-4712-ba45-a9e615e94366
+    hippo:availability: [live, preview]
+    hippotranslation:id: 062960e4-4dbf-40d6-bd7a-4b0207db5f00
+    hippotranslation:locale: inherited - from query
+    /selection:listitem[1]:
+      jcr:primaryType: selection:listitem
+      selection:key: ashford_and_st_peters_nhs_foundation_trust
+      selection:label: Ashford and St Peters NHS Foundation Trust
+    /selection:listitem[2]:
+      jcr:primaryType: selection:listitem
+      selection:key: aubrey_keep_library_and_knowledge_service
+      selection:label: Aubrey Keep Library and Knowledge Service
+    /selection:listitem[3]:
+      jcr:primaryType: selection:listitem
+      selection:key: barts_health
+      selection:label: Barts Health
+    /selection:listitem[4]:
+      jcr:primaryType: selection:listitem
+      selection:key: barts_health_nhs_trust
+      selection:label: Bart's Health NHS Trust
+    /selection:listitem[5]:
+      jcr:primaryType: selection:listitem
+      selection:key: barts_healthcare_library
+      selection:label: Barts Healthcare Library
+    /selection:listitem[6]:
+      jcr:primaryType: selection:listitem
+      selection:key: barts_hospital
+      selection:label: Barts Hospital
+    /selection:listitem[7]:
+      jcr:primaryType: selection:listitem
+      selection:key: birmingham_womens_and_childrens_nhs
+      selection:label: Birmingham Women's and Children's NHS
+    /selection:listitem[8]:
+      jcr:primaryType: selection:listitem
+      selection:key: brighton_and_sussex
+      selection:label: Brighton and Sussex
+    /selection:listitem[9]:
+      jcr:primaryType: selection:listitem
+      selection:key: brighton_and_sussex_healthcare
+      selection:label: Brighton and Sussex Healthcare
+    /selection:listitem[10]:
+      jcr:primaryType: selection:listitem
+      selection:key: brighton_and_sussex_library
+      selection:label: Brighton and Sussex Library
+    /selection:listitem[11]:
+      jcr:primaryType: selection:listitem
+      selection:key: brighton_and_sussex_library_and_knowledge_service
+      selection:label: Brighton and Sussex Library and Knowledge Service
+    /selection:listitem[12]:
+      jcr:primaryType: selection:listitem
+      selection:key: brighton_and_sussex_lks
+      selection:label: Brighton and Sussex LKS
+    /selection:listitem[13]:
+      jcr:primaryType: selection:listitem
+      selection:key: brighton_sussex
+      selection:label: Brighton & Sussex
+    /selection:listitem[14]:
+      jcr:primaryType: selection:listitem
+      selection:key: brighton_sussex_healthcare
+      selection:label: Brighton & Sussex Healthcare
+    /selection:listitem[15]:
+      jcr:primaryType: selection:listitem
+      selection:key: bwrdd_iechyd_prifysgol_bae_abertawe_library_services
+      selection:label: Bwrdd Iechyd Prifysgol Bae Abertawe Library Services
+    /selection:listitem[16]:
+      jcr:primaryType: selection:listitem
+      selection:key: croydon_university_hospital
+      selection:label: Croydon University Hospital
+    /selection:listitem[17]:
+      jcr:primaryType: selection:listitem
+      selection:key: derby_and_burton_hospitals
+      selection:label: Derby and Burton Hospitals
+    /selection:listitem[18]:
+      jcr:primaryType: selection:listitem
+      selection:key: derby_and_burton_nhs_foundation_trust
+      selection:label: Derby and Burton NHS Foundation Trust
+    /selection:listitem[19]:
+      jcr:primaryType: selection:listitem
+      selection:key: dorset_county_hospital
+      selection:label: Dorset County Hospital
+    /selection:listitem[20]:
+      jcr:primaryType: selection:listitem
+      selection:key: dorset_nhs
+      selection:label: Dorset NHS
+    /selection:listitem[21]:
+      jcr:primaryType: selection:listitem
+      selection:key: east_dorset
+      selection:label: East Dorset
+    /selection:listitem[22]:
+      jcr:primaryType: selection:listitem
+      selection:key: east_dorset_library_and_knowledge_service
+      selection:label: East Dorset Library and Knowledge Service
+    /selection:listitem[23]:
+      jcr:primaryType: selection:listitem
+      selection:key: east_dorset_library_knowledge_service
+      selection:label: East Dorset Library & Knowledge Service
+    /selection:listitem[24]:
+      jcr:primaryType: selection:listitem
+      selection:key: east_kent_hospitals
+      selection:label: East Kent Hospitals
+    /selection:listitem[25]:
+      jcr:primaryType: selection:listitem
+      selection:key: george_eliot_hospital
+      selection:label: George Eliot Hospital
+    /selection:listitem[26]:
+      jcr:primaryType: selection:listitem
+      selection:key: gloucestershire_health_and_care_nhs
+      selection:label: Gloucestershire Health and Care NHS
+    /selection:listitem[27]:
+      jcr:primaryType: selection:listitem
+      selection:key: gloucestershire_health_and_care_nhs_foundation_trust
+      selection:label: Gloucestershire Health and Care NHS Foundation Trust
+    /selection:listitem[28]:
+      jcr:primaryType: selection:listitem
+      selection:key: gloucestershire_hospitals
+      selection:label: Gloucestershire Hospitals
+    /selection:listitem[29]:
+      jcr:primaryType: selection:listitem
+      selection:key: hampshire_health_care
+      selection:label: Hampshire Health Care
+    /selection:listitem[30]:
+      jcr:primaryType: selection:listitem
+      selection:key: hampshire_healthcare
+      selection:label: Hampshire Healthcare
+    /selection:listitem[31]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_education_england
+      selection:label: Health Education England
+    /selection:listitem[32]:
+      jcr:primaryType: selection:listitem
+      selection:key: hee_km_team
+      selection:label: HEE KM Team
+    /selection:listitem[33]:
+      jcr:primaryType: selection:listitem
+      selection:key: kings_fund
+      selection:label: Kings Fund
+    /selection:listitem[34]:
+      jcr:primaryType: selection:listitem
+      selection:key: lancashire_teaching_hospitals_nhs_foundation_trust
+      selection:label: Lancashire Teaching Hospitals NHS Foundation Trust
+    /selection:listitem[35]:
+      jcr:primaryType: selection:listitem
+      selection:key: leicester_royal_infirmary_glenfield_hospital
+      selection:label: Leicester Royal Infirmary / Glenfield Hospital
+    /selection:listitem[36]:
+      jcr:primaryType: selection:listitem
+      selection:key: library_and_ks_kings_mill_hospital
+      selection:label: Library and KS Kings Mill Hospital
+    /selection:listitem[37]:
+      jcr:primaryType: selection:listitem
+      selection:key: library_knowledge_service_kings_mill_hospital
+      selection:label: Library & Knowledge Service Kings Mill Hospital
+    /selection:listitem[38]:
+      jcr:primaryType: selection:listitem
+      selection:key: lks_for_nhs_ambulance_services_in_england
+      selection:label: LKS for NHS Ambulance Services in England
+    /selection:listitem[39]:
+      jcr:primaryType: selection:listitem
+      selection:key: national_institute_for_health_and_care_excellence_nice
+      selection:label: National Institute for Health and Care Excellence (NICE)
+    /selection:listitem[40]:
+      jcr:primaryType: selection:listitem
+      selection:key: nelft_nhs_foundation_trust
+      selection:label: NELFT NHS Foundation Trust
+    /selection:listitem[41]:
+      jcr:primaryType: selection:listitem
+      selection:key: newcomb_library_and_information_service
+      selection:label: Newcomb Library and Information Service
+    /selection:listitem[42]:
+      jcr:primaryType: selection:listitem
+      selection:key: newcomb_library_library_and_information_service
+      selection:label: Newcomb Library Library and Information Service
+    /selection:listitem[43]:
+      jcr:primaryType: selection:listitem
+      selection:key: north_bristol_library_and_information_service
+      selection:label: North Bristol Library and Information Service
+    /selection:listitem[44]:
+      jcr:primaryType: selection:listitem
+      selection:key: north_bristol_nhs_trust
+      selection:label: North Bristol NHS Trust
+    /selection:listitem[45]:
+      jcr:primaryType: selection:listitem
+      selection:key: north_east_london
+      selection:label: North East London
+    /selection:listitem[46]:
+      jcr:primaryType: selection:listitem
+      selection:key: north_east_london_nhs
+      selection:label: North East London NHS
+    /selection:listitem[47]:
+      jcr:primaryType: selection:listitem
+      selection:key: north_east_london_nhs_foundation_trust
+      selection:label: North East London NHS Foundation Trust
+    /selection:listitem[48]:
+      jcr:primaryType: selection:listitem
+      selection:key: north_west_ambulance_service
+      selection:label: North West Ambulance Service
+    /selection:listitem[49]:
+      jcr:primaryType: selection:listitem
+      selection:key: northumbria_healthcare_library
+      selection:label: Northumbria Healthcare Library
+    /selection:listitem[50]:
+      jcr:primaryType: selection:listitem
+      selection:key: oxford_health_library
+      selection:label: Oxford Health Library
+    /selection:listitem[51]:
+      jcr:primaryType: selection:listitem
+      selection:key: oxford_health_library_and_knowledge_service
+      selection:label: Oxford Health Library and Knowledge Service
+    /selection:listitem[52]:
+      jcr:primaryType: selection:listitem
+      selection:key: poole_hospital_nhs
+      selection:label: Poole Hospital NHS
+    /selection:listitem[53]:
+      jcr:primaryType: selection:listitem
+      selection:key: public_health_bolton_council
+      selection:label: Public Health Bolton Council
+    /selection:listitem[54]:
+      jcr:primaryType: selection:listitem
+      selection:key: reay_house_library_and_knowledge_service
+      selection:label: Reay House Library and Knowledge Service
+    /selection:listitem[55]:
+      jcr:primaryType: selection:listitem
+      selection:key: royal_marsden_nhs
+      selection:label: Royal Marsden NHS
+    /selection:listitem[56]:
+      jcr:primaryType: selection:listitem
+      selection:key: royal_united_hospitals_bath_nhs
+      selection:label: Royal United Hospitals Bath NHS
+    /selection:listitem[57]:
+      jcr:primaryType: selection:listitem
+      selection:key: royal_wolverhampton
+      selection:label: Royal Wolverhampton
+    /selection:listitem[58]:
+      jcr:primaryType: selection:listitem
+      selection:key: royal_wolverhampton_nhs_trust
+      selection:label: Royal Wolverhampton NHS Trust
+    /selection:listitem[59]:
+      jcr:primaryType: selection:listitem
+      selection:key: salisbury_nhs
+      selection:label: Salisbury NHS
+    /selection:listitem[60]:
+      jcr:primaryType: selection:listitem
+      selection:key: salisbury_nhs_foundation_trust
+      selection:label: Salisbury NHS Foundation Trust
+    /selection:listitem[61]:
+      jcr:primaryType: selection:listitem
+      selection:key: sandwell_west_birmingham_hospitals
+      selection:label: Sandwell & West Birmingham Hospitals
+    /selection:listitem[62]:
+      jcr:primaryType: selection:listitem
+      selection:key: shrewsbury_and_telford_health
+      selection:label: Shrewsbury and Telford Health
+    /selection:listitem[63]:
+      jcr:primaryType: selection:listitem
+      selection:key: shrewsbury_and_telford_health_libraries
+      selection:label: Shrewsbury and Telford Health Libraries
+    /selection:listitem[64]:
+      jcr:primaryType: selection:listitem
+      selection:key: shrewsbury_and_telford_healthcare
+      selection:label: Shrewsbury and Telford Healthcare
+    /selection:listitem[65]:
+      jcr:primaryType: selection:listitem
+      selection:key: shrewsbury_telford_health_libraries
+      selection:label: Shrewsbury & Telford Health Libraries
+    /selection:listitem[66]:
+      jcr:primaryType: selection:listitem
+      selection:key: south_london_and_maudsley_nhs_foundation_trust
+      selection:label: South London and Maudsley NHS Foundation Trust
+    /selection:listitem[67]:
+      jcr:primaryType: selection:listitem
+      selection:key: south_london_maudsley_nhs
+      selection:label: South London & Maudsley NHS
+    /selection:listitem[68]:
+      jcr:primaryType: selection:listitem
+      selection:key: south_london_maudsley_nhs_foundation_trust
+      selection:label: South London & Maudsley NHS Foundation Trust
+    /selection:listitem[69]:
+      jcr:primaryType: selection:listitem
+      selection:key: surrey_and_sussex_healthcare
+      selection:label: Surrey and Sussex Healthcare
+    /selection:listitem[70]:
+      jcr:primaryType: selection:listitem
+      selection:key: surrey_and_sussex_healthcare_nhs_trust
+      selection:label: Surrey and Sussex Healthcare NHS Trust
+    /selection:listitem[71]:
+      jcr:primaryType: selection:listitem
+      selection:key: surrey_and_sussex_library
+      selection:label: Surrey and Sussex Library
+    /selection:listitem[72]:
+      jcr:primaryType: selection:listitem
+      selection:key: surrey_sussex_healthcare
+      selection:label: Surrey & Sussex Healthcare
+    /selection:listitem[73]:
+      jcr:primaryType: selection:listitem
+      selection:key: swansea_bay_university_healthboard
+      selection:label: Swansea Bay University Healthboard
+    /selection:listitem[74]:
+      jcr:primaryType: selection:listitem
+      selection:key: the_royal_wolverhampton_nhs_trust_library_and_knowledge_service
+      selection:label: The Royal Wolverhampton NHS Trust Library and Knowledge Service
+    /selection:listitem[75]:
+      jcr:primaryType: selection:listitem
+      selection:key: university_hospitals_birmingham_uhb_library_and_knowledge_service
+      selection:label: University Hospitals Birmingham (UHB) Library and Knowledge
+        Service
+    /selection:listitem[76]:
+      jcr:primaryType: selection:listitem
+      selection:key: university_hospitals_bristol_and_weston_nhs
+      selection:label: University Hospitals Bristol and Weston NHS
+    /selection:listitem[77]:
+      jcr:primaryType: selection:listitem
+      selection:key: university_hospitals_bristol_and_weston_nhs_foundation_trust
+      selection:label: University Hospitals Bristol and Weston NHS Foundation Trust
+    /selection:listitem[78]:
+      jcr:primaryType: selection:listitem
+      selection:key: university_hospitals_leicester
+      selection:label: University Hospitals Leicester
+    /selection:listitem[79]:
+      jcr:primaryType: selection:listitem
+      selection:key: university_hospitals_of_derby_and_burton
+      selection:label: University Hospitals of Derby and Burton
+    /selection:listitem[80]:
+      jcr:primaryType: selection:listitem
+      selection:key: university_hospitals_of_derby_and_burton_nhs
+      selection:label: University Hospitals of Derby and Burton NHS
+    /selection:listitem[81]:
+      jcr:primaryType: selection:listitem
+      selection:key: university_hospitals_of_derby_and_burton_nhs_foundation_trust
+      selection:label: University Hospitals of Derby and Burton NHS Foundation Trust
+    /selection:listitem[82]:
+      jcr:primaryType: selection:listitem
+      selection:key: university_hospitals_of_derby_burton
+      selection:label: University Hospitals of Derby & Burton
+    /selection:listitem[83]:
+      jcr:primaryType: selection:listitem
+      selection:key: university_hospitals_of_derby_burton_nhs_foundation_trust
+      selection:label: University Hospitals of Derby & Burton NHS Foundation Trust
+    /selection:listitem[84]:
+      jcr:primaryType: selection:listitem
+      selection:key: university_hospitals_of_leicester_nhs_trust_libraries
+      selection:label: University Hospitals of Leicester NHS Trust Libraries
+    /selection:listitem[85]:
+      jcr:primaryType: selection:listitem
+      selection:key: warrington_and_halton_hospitals_nhs
+      selection:label: Warrington and Halton Hospitals NHS
+    /selection:listitem[86]:
+      jcr:primaryType: selection:listitem
+      selection:key: west_middlesex_university_hospital
+      selection:label: West Middlesex University Hospital
+    /selection:listitem[87]:
+      jcr:primaryType: selection:listitem
+      selection:key: west_suffolk_nhs
+      selection:label: West Suffolk NHS

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/kls/searchbanktopics.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/kls/searchbanktopics.yaml
@@ -1,24 +1,952 @@
 /content/documents/administration/valuelists/kls/searchbanktopics:
   jcr:primaryType: hippo:handle
   jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  jcr:uuid: a06957b3-e1dd-43d8-aad0-1d5647ed87ed
+  jcr:uuid: 99e333f1-c54d-43a9-a63f-daff028aafb9
   hippo:name: SearchBankTopics
   /searchbanktopics:
     jcr:primaryType: selection:valuelist
     jcr:mixinTypes: ['hippotranslation:translated', 'mix:referenceable']
-    jcr:uuid: c7d3a495-dc08-4217-9338-e816fa14d8d5
+    jcr:uuid: 4777cca3-fd67-4b40-8a4a-69c645b33260
     hippo:availability: [live, preview]
-    hippotranslation:id: 115f4ff0-3029-4460-beb2-9197f1904688
+    hippotranslation:id: 86f2d8d8-73be-4928-a916-7a9682cf948d
     hippotranslation:locale: inherited - from query
     /selection:listitem[1]:
       jcr:primaryType: selection:listitem
-      selection:key: prevention
-      selection:label: Prevention
+      selection:key: 3d_printing
+      selection:label: 3D printing
     /selection:listitem[2]:
+      jcr:primaryType: selection:listitem
+      selection:key: abuse
+      selection:label: Abuse
+    /selection:listitem[3]:
+      jcr:primaryType: selection:listitem
+      selection:key: acute_respiratory_distress_syndrome
+      selection:label: Acute respiratory distress syndrome
+    /selection:listitem[4]:
+      jcr:primaryType: selection:listitem
+      selection:key: admission
+      selection:label: Admission
+    /selection:listitem[5]:
+      jcr:primaryType: selection:listitem
+      selection:key: adverse_experience_children
+      selection:label: Adverse experience children
+    /selection:listitem[6]:
+      jcr:primaryType: selection:listitem
+      selection:key: aerosol_generating_procedures
+      selection:label: Aerosol generating procedures
+    /selection:listitem[7]:
+      jcr:primaryType: selection:listitem
+      selection:key: aged
+      selection:label: Aged
+    /selection:listitem[8]:
+      jcr:primaryType: selection:listitem
+      selection:key: airway
+      selection:label: Airway
+    /selection:listitem[9]:
+      jcr:primaryType: selection:listitem
+      selection:key: ambulances
+      selection:label: Ambulances
+    /selection:listitem[10]:
+      jcr:primaryType: selection:listitem
+      selection:key: anaesthesia
+      selection:label: Anaesthesia
+    /selection:listitem[11]:
+      jcr:primaryType: selection:listitem
+      selection:key: angiotensin-converting_enzyme_2
+      selection:label: Angiotensin-converting enzyme 2
+    /selection:listitem[12]:
+      jcr:primaryType: selection:listitem
+      selection:key: angiotensin-converting_enzyme_inhibitors
+      selection:label: Angiotensin-converting enzyme inhibitors
+    /selection:listitem[13]:
+      jcr:primaryType: selection:listitem
+      selection:key: antibodies
+      selection:label: Antibodies
+    /selection:listitem[14]:
+      jcr:primaryType: selection:listitem
+      selection:key: asthma
+      selection:label: Asthma
+    /selection:listitem[15]:
+      jcr:primaryType: selection:listitem
+      selection:key: atrial_fibrillation
+      selection:label: Atrial fibrillation
+    /selection:listitem[16]:
+      jcr:primaryType: selection:listitem
+      selection:key: autism
+      selection:label: Autism
+    /selection:listitem[17]:
+      jcr:primaryType: selection:listitem
+      selection:key: bame
+      selection:label: BAME
+    /selection:listitem[18]:
+      jcr:primaryType: selection:listitem
+      selection:key: birth
+      selection:label: Birth
+    /selection:listitem[19]:
+      jcr:primaryType: selection:listitem
+      selection:key: blood
+      selection:label: Blood
+    /selection:listitem[20]:
+      jcr:primaryType: selection:listitem
+      selection:key: body_fluids
+      selection:label: Body Fluids
+    /selection:listitem[21]:
+      jcr:primaryType: selection:listitem
+      selection:key: bone_marrow
+      selection:label: Bone marrow
+    /selection:listitem[22]:
+      jcr:primaryType: selection:listitem
+      selection:key: business_continuity
+      selection:label: Business continuity
+    /selection:listitem[23]:
+      jcr:primaryType: selection:listitem
+      selection:key: cancer
+      selection:label: Cancer
+    /selection:listitem[24]:
+      jcr:primaryType: selection:listitem
+      selection:key: cardiac
+      selection:label: Cardiac
+    /selection:listitem[25]:
+      jcr:primaryType: selection:listitem
+      selection:key: cardiology
+      selection:label: Cardiology
+    /selection:listitem[26]:
+      jcr:primaryType: selection:listitem
+      selection:key: care
+      selection:label: Care
+    /selection:listitem[27]:
+      jcr:primaryType: selection:listitem
+      selection:key: chaplaincy
+      selection:label: Chaplaincy
+    /selection:listitem[28]:
+      jcr:primaryType: selection:listitem
+      selection:key: children
+      selection:label: Children
+    /selection:listitem[29]:
+      jcr:primaryType: selection:listitem
+      selection:key: circulation
+      selection:label: Circulation
+    /selection:listitem[30]:
+      jcr:primaryType: selection:listitem
+      selection:key: cleaning
+      selection:label: Cleaning
+    /selection:listitem[31]:
+      jcr:primaryType: selection:listitem
+      selection:key: clinical_training
+      selection:label: Clinical training
+    /selection:listitem[32]:
+      jcr:primaryType: selection:listitem
+      selection:key: communication
+      selection:label: Communication
+    /selection:listitem[33]:
+      jcr:primaryType: selection:listitem
+      selection:key: complications
+      selection:label: Complications
+    /selection:listitem[34]:
+      jcr:primaryType: selection:listitem
+      selection:key: consultations
+      selection:label: Consultations
+    /selection:listitem[35]:
+      jcr:primaryType: selection:listitem
+      selection:key: cortisone
+      selection:label: Cortisone
+    /selection:listitem[36]:
+      jcr:primaryType: selection:listitem
+      selection:key: cpap
+      selection:label: cpap
+    /selection:listitem[37]:
+      jcr:primaryType: selection:listitem
+      selection:key: cpe
+      selection:label: CPE
+    /selection:listitem[38]:
+      jcr:primaryType: selection:listitem
+      selection:key: cranial_nerves
+      selection:label: Cranial Nerves
+    /selection:listitem[39]:
+      jcr:primaryType: selection:listitem
+      selection:key: crises
+      selection:label: Crises
+    /selection:listitem[40]:
+      jcr:primaryType: selection:listitem
+      selection:key: critical_care
+      selection:label: Critical care
+    /selection:listitem[41]:
+      jcr:primaryType: selection:listitem
+      selection:key: ct_scan
+      selection:label: CT scan
+    /selection:listitem[42]:
+      jcr:primaryType: selection:listitem
+      selection:key: cvd
+      selection:label: CVD
+    /selection:listitem[43]:
+      jcr:primaryType: selection:listitem
+      selection:key: debriefing
+      selection:label: Debriefing
+    /selection:listitem[44]:
+      jcr:primaryType: selection:listitem
+      selection:key: dentistry
+      selection:label: Dentistry
+    /selection:listitem[45]:
+      jcr:primaryType: selection:listitem
+      selection:key: dermatology
+      selection:label: Dermatology
+    /selection:listitem[46]:
+      jcr:primaryType: selection:listitem
+      selection:key: diagnosis
+      selection:label: Diagnosis
+    /selection:listitem[47]:
+      jcr:primaryType: selection:listitem
+      selection:key: diet
+      selection:label: diet
+    /selection:listitem[48]:
+      jcr:primaryType: selection:listitem
+      selection:key: digital_divide
+      selection:label: Digital divide
+    /selection:listitem[49]:
+      jcr:primaryType: selection:listitem
+      selection:key: digital_inclusion
+      selection:label: Digital inclusion
+    /selection:listitem[50]:
+      jcr:primaryType: selection:listitem
+      selection:key: digital_inequality
+      selection:label: Digital inequality
+    /selection:listitem[51]:
+      jcr:primaryType: selection:listitem
+      selection:key: disinfection
+      selection:label: Disinfection
+    /selection:listitem[52]:
+      jcr:primaryType: selection:listitem
+      selection:key: doctors
+      selection:label: Doctors
+    /selection:listitem[53]:
+      jcr:primaryType: selection:listitem
+      selection:key: domicilary_care
+      selection:label: Domicilary care
+    /selection:listitem[54]:
+      jcr:primaryType: selection:listitem
+      selection:key: drug_users
+      selection:label: Drug Users
+    /selection:listitem[55]:
+      jcr:primaryType: selection:listitem
+      selection:key: dvt
+      selection:label: DVT
+    /selection:listitem[56]:
+      jcr:primaryType: selection:listitem
+      selection:key: dysphagia
+      selection:label: Dysphagia
+    /selection:listitem[57]:
+      jcr:primaryType: selection:listitem
+      selection:key: e-cigarettes
+      selection:label: E-cigarettes
+    /selection:listitem[58]:
+      jcr:primaryType: selection:listitem
+      selection:key: early_warning_score
+      selection:label: Early Warning Score
+    /selection:listitem[59]:
+      jcr:primaryType: selection:listitem
+      selection:key: ecmo
+      selection:label: ECMO
+    /selection:listitem[60]:
+      jcr:primaryType: selection:listitem
+      selection:key: ectopic_pregnancy
+      selection:label: Ectopic pregnancy
+    /selection:listitem[61]:
+      jcr:primaryType: selection:listitem
+      selection:key: education
+      selection:label: Education
+    /selection:listitem[62]:
+      jcr:primaryType: selection:listitem
+      selection:key: embolism
+      selection:label: Embolism
+    /selection:listitem[63]:
       jcr:primaryType: selection:listitem
       selection:key: emergency
       selection:label: Emergency
-    /selection:listitem[3]:
+    /selection:listitem[64]:
+      jcr:primaryType: selection:listitem
+      selection:key: emergency_department
+      selection:label: Emergency department
+    /selection:listitem[65]:
+      jcr:primaryType: selection:listitem
+      selection:key: end_of_life
+      selection:label: End of Life
+    /selection:listitem[66]:
+      jcr:primaryType: selection:listitem
+      selection:key: enteritis
+      selection:label: Enteritis
+    /selection:listitem[67]:
+      jcr:primaryType: selection:listitem
+      selection:key: epidemiology
+      selection:label: Epidemiology
+    /selection:listitem[68]:
+      jcr:primaryType: selection:listitem
+      selection:key: epidermolysis_bullosa
+      selection:label: Epidermolysis bullosa
+    /selection:listitem[69]:
+      jcr:primaryType: selection:listitem
+      selection:key: equipment_re-use
+      selection:label: Equipment re-use
+    /selection:listitem[70]:
+      jcr:primaryType: selection:listitem
+      selection:key: equipment_reuse
+      selection:label: Equipment reuse
+    /selection:listitem[71]:
+      jcr:primaryType: selection:listitem
+      selection:key: ethics
+      selection:label: Ethics
+    /selection:listitem[72]:
+      jcr:primaryType: selection:listitem
+      selection:key: exercise
+      selection:label: Exercise
+    /selection:listitem[73]:
+      jcr:primaryType: selection:listitem
+      selection:key: exit_strategy
+      selection:label: Exit Strategy
+    /selection:listitem[74]:
+      jcr:primaryType: selection:listitem
+      selection:key: extubation
+      selection:label: Extubation
+    /selection:listitem[75]:
+      jcr:primaryType: selection:listitem
+      selection:key: eye
+      selection:label: Eye
+    /selection:listitem[76]:
+      jcr:primaryType: selection:listitem
+      selection:key: falls
+      selection:label: Falls
+    /selection:listitem[77]:
+      jcr:primaryType: selection:listitem
+      selection:key: family
+      selection:label: Family
+    /selection:listitem[78]:
+      jcr:primaryType: selection:listitem
+      selection:key: financial_advice
+      selection:label: Financial advice
+    /selection:listitem[79]:
+      jcr:primaryType: selection:listitem
+      selection:key: food_parcels
+      selection:label: food parcels
+    /selection:listitem[80]:
+      jcr:primaryType: selection:listitem
+      selection:key: fractures
+      selection:label: Fractures
+    /selection:listitem[81]:
+      jcr:primaryType: selection:listitem
+      selection:key: frailty
+      selection:label: Frailty
+    /selection:listitem[82]:
+      jcr:primaryType: selection:listitem
+      selection:key: g6pd_deficiency
+      selection:label: G6PD deficiency
+    /selection:listitem[83]:
+      jcr:primaryType: selection:listitem
+      selection:key: general_practice
+      selection:label: General practice
+    /selection:listitem[84]:
+      jcr:primaryType: selection:listitem
+      selection:key: gloves
+      selection:label: Gloves
+    /selection:listitem[85]:
+      jcr:primaryType: selection:listitem
+      selection:key: grief
+      selection:label: Grief
+    /selection:listitem[86]:
+      jcr:primaryType: selection:listitem
+      selection:key: haematology
+      selection:label: Haematology
+    /selection:listitem[87]:
+      jcr:primaryType: selection:listitem
+      selection:key: hand_washing
+      selection:label: Hand washing
+    /selection:listitem[88]:
+      jcr:primaryType: selection:listitem
+      selection:key: handwashing
+      selection:label: Handwashing
+    /selection:listitem[89]:
+      jcr:primaryType: selection:listitem
+      selection:key: health_care_delivery
+      selection:label: Health care delivery
+    /selection:listitem[90]:
+      jcr:primaryType: selection:listitem
+      selection:key: healthcare_disparities
+      selection:label: Healthcare Disparities
+    /selection:listitem[91]:
+      jcr:primaryType: selection:listitem
+      selection:key: healthcare_staff
+      selection:label: healthcare staff
+    /selection:listitem[92]:
+      jcr:primaryType: selection:listitem
+      selection:key: heart
+      selection:label: Heart
+    /selection:listitem[93]:
+      jcr:primaryType: selection:listitem
+      selection:key: hydroxychloroquine_azithromycin_outcomes
+      selection:label: Hydroxychloroquine Azithromycin Outcomes
+    /selection:listitem[94]:
+      jcr:primaryType: selection:listitem
+      selection:key: hydroxyychloroquine
+      selection:label: Hydroxyychloroquine
+    /selection:listitem[95]:
+      jcr:primaryType: selection:listitem
+      selection:key: hypoxia
+      selection:label: Hypoxia
+    /selection:listitem[96]:
+      jcr:primaryType: selection:listitem
+      selection:key: icu
+      selection:label: ICU
+    /selection:listitem[97]:
+      jcr:primaryType: selection:listitem
+      selection:key: illicit_drugs
+      selection:label: Illicit Drugs
+    /selection:listitem[98]:
+      jcr:primaryType: selection:listitem
+      selection:key: immune_system
+      selection:label: Immune system
+    /selection:listitem[99]:
+      jcr:primaryType: selection:listitem
+      selection:key: impact
+      selection:label: Impact
+    /selection:listitem[100]:
+      jcr:primaryType: selection:listitem
+      selection:key: incubation
+      selection:label: Incubation
+    /selection:listitem[101]:
+      jcr:primaryType: selection:listitem
+      selection:key: infection
+      selection:label: Infection
+    /selection:listitem[102]:
+      jcr:primaryType: selection:listitem
+      selection:key: infection_control
+      selection:label: Infection Control
+    /selection:listitem[103]:
+      jcr:primaryType: selection:listitem
+      selection:key: infectious
+      selection:label: Infectious
+    /selection:listitem[104]:
+      jcr:primaryType: selection:listitem
+      selection:key: inflammation
+      selection:label: Inflammation
+    /selection:listitem[105]:
+      jcr:primaryType: selection:listitem
+      selection:key: inpatients
+      selection:label: Inpatients
+    /selection:listitem[106]:
+      jcr:primaryType: selection:listitem
+      selection:key: ipap
+      selection:label: ipap
+    /selection:listitem[107]:
+      jcr:primaryType: selection:listitem
+      selection:key: isolation
+      selection:label: Isolation
+    /selection:listitem[108]:
+      jcr:primaryType: selection:listitem
+      selection:key: it_equipment
+      selection:label: IT Equipment
+    /selection:listitem[109]:
+      jcr:primaryType: selection:listitem
+      selection:key: ivermectin
+      selection:label: Ivermectin
+    /selection:listitem[110]:
+      jcr:primaryType: selection:listitem
+      selection:key: kawasaki_disease
+      selection:label: Kawasaki disease
+    /selection:listitem[111]:
+      jcr:primaryType: selection:listitem
+      selection:key: kidney
+      selection:label: Kidney
+    /selection:listitem[112]:
+      jcr:primaryType: selection:listitem
+      selection:key: knowledge_capture
+      selection:label: Knowledge capture
+    /selection:listitem[113]:
+      jcr:primaryType: selection:listitem
+      selection:key: laboratory
+      selection:label: Laboratory
+    /selection:listitem[114]:
+      jcr:primaryType: selection:listitem
+      selection:key: learning
+      selection:label: Learning
+    /selection:listitem[115]:
+      jcr:primaryType: selection:listitem
+      selection:key: learning_disabilities
+      selection:label: Learning disabilities
+    /selection:listitem[116]:
+      jcr:primaryType: selection:listitem
+      selection:key: lessons_learned
+      selection:label: Lessons learned
+    /selection:listitem[117]:
+      jcr:primaryType: selection:listitem
+      selection:key: lockdown
+      selection:label: Lockdown
+    /selection:listitem[118]:
+      jcr:primaryType: selection:listitem
+      selection:key: long_covid
+      selection:label: Long COVID
+    /selection:listitem[119]:
+      jcr:primaryType: selection:listitem
+      selection:key: management
+      selection:label: Management
+    /selection:listitem[120]:
+      jcr:primaryType: selection:listitem
+      selection:key: masks
+      selection:label: Masks
+    /selection:listitem[121]:
+      jcr:primaryType: selection:listitem
+      selection:key: maternity
+      selection:label: Maternity
+    /selection:listitem[122]:
+      jcr:primaryType: selection:listitem
+      selection:key: mental_disorders
+      selection:label: Mental Disorders
+    /selection:listitem[123]:
+      jcr:primaryType: selection:listitem
+      selection:key: mental_health
+      selection:label: mental health
+    /selection:listitem[124]:
+      jcr:primaryType: selection:listitem
+      selection:key: mers
+      selection:label: MERS
+    /selection:listitem[125]:
+      jcr:primaryType: selection:listitem
+      selection:key: military
+      selection:label: Military
+    /selection:listitem[126]:
+      jcr:primaryType: selection:listitem
+      selection:key: minority_groups
+      selection:label: Minority Groups
+    /selection:listitem[127]:
+      jcr:primaryType: selection:listitem
+      selection:key: monitoring
+      selection:label: Monitoring
+    /selection:listitem[128]:
+      jcr:primaryType: selection:listitem
+      selection:key: morbidity
+      selection:label: morbidity
+    /selection:listitem[129]:
+      jcr:primaryType: selection:listitem
+      selection:key: mortality
+      selection:label: Mortality
+    /selection:listitem[130]:
+      jcr:primaryType: selection:listitem
+      selection:key: music
+      selection:label: Music
+    /selection:listitem[131]:
+      jcr:primaryType: selection:listitem
+      selection:key: nasopharyngeal
+      selection:label: nasopharyngeal
+    /selection:listitem[132]:
+      jcr:primaryType: selection:listitem
+      selection:key: nephrology
+      selection:label: Nephrology
+    /selection:listitem[133]:
+      jcr:primaryType: selection:listitem
+      selection:key: neurological_manifestations
+      selection:label: Neurological manifestations
+    /selection:listitem[134]:
+      jcr:primaryType: selection:listitem
+      selection:key: noninvasive_ventilation
+      selection:label: Noninvasive ventilation
+    /selection:listitem[135]:
+      jcr:primaryType: selection:listitem
+      selection:key: nutrition
+      selection:label: Nutrition
+    /selection:listitem[136]:
+      jcr:primaryType: selection:listitem
+      selection:key: occupational_health
+      selection:label: Occupational health
+    /selection:listitem[137]:
+      jcr:primaryType: selection:listitem
+      selection:key: osteoporosis
+      selection:label: Osteoporosis
+    /selection:listitem[138]:
+      jcr:primaryType: selection:listitem
+      selection:key: oulmonary_arteries
+      selection:label: Oulmonary arteries
+    /selection:listitem[139]:
+      jcr:primaryType: selection:listitem
+      selection:key: outcomes
+      selection:label: Outcomes
+    /selection:listitem[140]:
+      jcr:primaryType: selection:listitem
+      selection:key: oxygen
+      selection:label: Oxygen
+    /selection:listitem[141]:
+      jcr:primaryType: selection:listitem
+      selection:key: paediatric_inflammatory_multisystem_syndrome
+      selection:label: Paediatric inflammatory multisystem Syndrome
+    /selection:listitem[142]:
+      jcr:primaryType: selection:listitem
+      selection:key: palliative_care
+      selection:label: Palliative care
+    /selection:listitem[143]:
+      jcr:primaryType: selection:listitem
+      selection:key: paper
+      selection:label: Paper
+    /selection:listitem[144]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient_assessment
+      selection:label: Patient assessment
+    /selection:listitem[145]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient_referral
+      selection:label: Patient referral
+    /selection:listitem[146]:
+      jcr:primaryType: selection:listitem
+      selection:key: patient_transport
+      selection:label: Patient transport
+    /selection:listitem[147]:
+      jcr:primaryType: selection:listitem
+      selection:key: peripheral_nerve
+      selection:label: Peripheral nerve
+    /selection:listitem[148]:
+      jcr:primaryType: selection:listitem
+      selection:key: peripheral_neuropathy
+      selection:label: Peripheral neuropathy
+    /selection:listitem[149]:
+      jcr:primaryType: selection:listitem
+      selection:key: physiotherapy
+      selection:label: Physiotherapy
+    /selection:listitem[150]:
+      jcr:primaryType: selection:listitem
+      selection:key: position
+      selection:label: Position
+    /selection:listitem[151]:
+      jcr:primaryType: selection:listitem
+      selection:key: post-covid
+      selection:label: Post-COVID
+    /selection:listitem[152]:
+      jcr:primaryType: selection:listitem
+      selection:key: post-pandemic
+      selection:label: Post-pandemic
+    /selection:listitem[153]:
+      jcr:primaryType: selection:listitem
+      selection:key: post-traumatic_stress
+      selection:label: Post-traumatic stress
+    /selection:listitem[154]:
+      jcr:primaryType: selection:listitem
+      selection:key: ppe
+      selection:label: PPE
+    /selection:listitem[155]:
+      jcr:primaryType: selection:listitem
+      selection:key: prediction
+      selection:label: Prediction
+    /selection:listitem[156]:
+      jcr:primaryType: selection:listitem
+      selection:key: pregnancy
+      selection:label: Pregnancy
+    /selection:listitem[157]:
+      jcr:primaryType: selection:listitem
+      selection:key: prehabilitation
+      selection:label: Prehabilitation
+    /selection:listitem[158]:
+      jcr:primaryType: selection:listitem
+      selection:key: prevention
+      selection:label: Prevention
+    /selection:listitem[159]:
+      jcr:primaryType: selection:listitem
+      selection:key: primary_care
+      selection:label: Primary care
+    /selection:listitem[160]:
+      jcr:primaryType: selection:listitem
+      selection:key: prioritisation
+      selection:label: Prioritisation
+    /selection:listitem[161]:
+      jcr:primaryType: selection:listitem
+      selection:key: prognosis
+      selection:label: Prognosis
+    /selection:listitem[162]:
+      jcr:primaryType: selection:listitem
+      selection:key: prone
+      selection:label: Prone
+    /selection:listitem[163]:
+      jcr:primaryType: selection:listitem
+      selection:key: proned
+      selection:label: Proned
+    /selection:listitem[164]:
+      jcr:primaryType: selection:listitem
+      selection:key: proning
+      selection:label: Proning
+    /selection:listitem[165]:
+      jcr:primaryType: selection:listitem
+      selection:key: psychiatry
+      selection:label: Psychiatry
+    /selection:listitem[166]:
+      jcr:primaryType: selection:listitem
+      selection:key: psychology
+      selection:label: psychology
+    /selection:listitem[167]:
+      jcr:primaryType: selection:listitem
+      selection:key: public_health
+      selection:label: Public health
+    /selection:listitem[168]:
+      jcr:primaryType: selection:listitem
+      selection:key: pulmonary_arteries
+      selection:label: Pulmonary Arteries
+    /selection:listitem[169]:
+      jcr:primaryType: selection:listitem
+      selection:key: pulmonary_veins
+      selection:label: Pulmonary veins
+    /selection:listitem[170]:
+      jcr:primaryType: selection:listitem
+      selection:key: quality_improvement
+      selection:label: Quality improvement
+    /selection:listitem[171]:
+      jcr:primaryType: selection:listitem
+      selection:key: quarantine
+      selection:label: Quarantine
+    /selection:listitem[172]:
+      jcr:primaryType: selection:listitem
+      selection:key: records
+      selection:label: Records
+    /selection:listitem[173]:
       jcr:primaryType: selection:listitem
       selection:key: recovery
       selection:label: Recovery
+    /selection:listitem[174]:
+      jcr:primaryType: selection:listitem
+      selection:key: recurrence
+      selection:label: Recurrence
+    /selection:listitem[175]:
+      jcr:primaryType: selection:listitem
+      selection:key: rehabilitation
+      selection:label: Rehabilitation
+    /selection:listitem[176]:
+      jcr:primaryType: selection:listitem
+      selection:key: renal
+      selection:label: Renal
+    /selection:listitem[177]:
+      jcr:primaryType: selection:listitem
+      selection:key: resilience
+      selection:label: resilience
+    /selection:listitem[178]:
+      jcr:primaryType: selection:listitem
+      selection:key: respiratory
+      selection:label: Respiratory
+    /selection:listitem[179]:
+      jcr:primaryType: selection:listitem
+      selection:key: reverse_transcriptase_polymerase_chain_reaction
+      selection:label: Reverse transcriptase polymerase chain reaction
+    /selection:listitem[180]:
+      jcr:primaryType: selection:listitem
+      selection:key: risk
+      selection:label: Risk
+    /selection:listitem[181]:
+      jcr:primaryType: selection:listitem
+      selection:key: risk_factors
+      selection:label: risk factors
+    /selection:listitem[182]:
+      jcr:primaryType: selection:listitem
+      selection:key: risk_score
+      selection:label: Risk Score
+    /selection:listitem[183]:
+      jcr:primaryType: selection:listitem
+      selection:key: sars
+      selection:label: SARS
+    /selection:listitem[184]:
+      jcr:primaryType: selection:listitem
+      selection:key: schools
+      selection:label: Schools
+    /selection:listitem[185]:
+      jcr:primaryType: selection:listitem
+      selection:key: screening
+      selection:label: Screening
+    /selection:listitem[186]:
+      jcr:primaryType: selection:listitem
+      selection:key: secondary_care
+      selection:label: Secondary care
+    /selection:listitem[187]:
+      jcr:primaryType: selection:listitem
+      selection:key: sense_of_smell
+      selection:label: Sense of smell
+    /selection:listitem[188]:
+      jcr:primaryType: selection:listitem
+      selection:key: service_provision
+      selection:label: Service provision
+    /selection:listitem[189]:
+      jcr:primaryType: selection:listitem
+      selection:key: simulation
+      selection:label: Simulation
+    /selection:listitem[190]:
+      jcr:primaryType: selection:listitem
+      selection:key: skin
+      selection:label: Skin
+    /selection:listitem[191]:
+      jcr:primaryType: selection:listitem
+      selection:key: smoking
+      selection:label: Smoking
+    /selection:listitem[192]:
+      jcr:primaryType: selection:listitem
+      selection:key: social_distancing
+      selection:label: social Distancing
+    /selection:listitem[193]:
+      jcr:primaryType: selection:listitem
+      selection:key: speech
+      selection:label: Speech
+    /selection:listitem[194]:
+      jcr:primaryType: selection:listitem
+      selection:key: spirometry
+      selection:label: Spirometry
+    /selection:listitem[195]:
+      jcr:primaryType: selection:listitem
+      selection:key: squamous_cell_carcinoma
+      selection:label: Squamous cell carcinoma
+    /selection:listitem[196]:
+      jcr:primaryType: selection:listitem
+      selection:key: staff_morale
+      selection:label: Staff morale
+    /selection:listitem[197]:
+      jcr:primaryType: selection:listitem
+      selection:key: statistics
+      selection:label: Statistics
+    /selection:listitem[198]:
+      jcr:primaryType: selection:listitem
+      selection:key: students
+      selection:label: students
+    /selection:listitem[199]:
+      jcr:primaryType: selection:listitem
+      selection:key: substance-related_disorders
+      selection:label: Substance-Related Disorders
+    /selection:listitem[200]:
+      jcr:primaryType: selection:listitem
+      selection:key: substance_related_disorders
+      selection:label: Substance related disorders
+    /selection:listitem[201]:
+      jcr:primaryType: selection:listitem
+      selection:key: surfaces
+      selection:label: Surfaces
+    /selection:listitem[202]:
+      jcr:primaryType: selection:listitem
+      selection:key: surgery
+      selection:label: Surgery
+    /selection:listitem[203]:
+      jcr:primaryType: selection:listitem
+      selection:key: surveillance
+      selection:label: Surveillance
+    /selection:listitem[204]:
+      jcr:primaryType: selection:listitem
+      selection:key: swab
+      selection:label: Swab
+    /selection:listitem[205]:
+      jcr:primaryType: selection:listitem
+      selection:key: symptom_control
+      selection:label: Symptom control
+    /selection:listitem[206]:
+      jcr:primaryType: selection:listitem
+      selection:key: technology
+      selection:label: Technology
+    /selection:listitem[207]:
+      jcr:primaryType: selection:listitem
+      selection:key: telehealth
+      selection:label: Telehealth
+    /selection:listitem[208]:
+      jcr:primaryType: selection:listitem
+      selection:key: test_accuracy
+      selection:label: Test accuracy
+    /selection:listitem[209]:
+      jcr:primaryType: selection:listitem
+      selection:key: testing
+      selection:label: Testing
+    /selection:listitem[210]:
+      jcr:primaryType: selection:listitem
+      selection:key: tests
+      selection:label: Tests
+    /selection:listitem[211]:
+      jcr:primaryType: selection:listitem
+      selection:key: theatres
+      selection:label: Theatres
+    /selection:listitem[212]:
+      jcr:primaryType: selection:listitem
+      selection:key: therapy
+      selection:label: Therapy
+    /selection:listitem[213]:
+      jcr:primaryType: selection:listitem
+      selection:key: thrombosis
+      selection:label: Thrombosis
+    /selection:listitem[214]:
+      jcr:primaryType: selection:listitem
+      selection:key: tracing
+      selection:label: Tracing
+    /selection:listitem[215]:
+      jcr:primaryType: selection:listitem
+      selection:key: transmission
+      selection:label: Transmission
+    /selection:listitem[216]:
+      jcr:primaryType: selection:listitem
+      selection:key: trauma_care
+      selection:label: Trauma care
+    /selection:listitem[217]:
+      jcr:primaryType: selection:listitem
+      selection:key: treatment
+      selection:label: Treatment
+    /selection:listitem[218]:
+      jcr:primaryType: selection:listitem
+      selection:key: treatment_withdrawal
+      selection:label: Treatment withdrawal
+    /selection:listitem[219]:
+      jcr:primaryType: selection:listitem
+      selection:key: trends
+      selection:label: Trends
+    /selection:listitem[220]:
+      jcr:primaryType: selection:listitem
+      selection:key: unintended_consequences
+      selection:label: Unintended consequences
+    /selection:listitem[221]:
+      jcr:primaryType: selection:listitem
+      selection:key: vaccination
+      selection:label: Vaccination
+    /selection:listitem[222]:
+      jcr:primaryType: selection:listitem
+      selection:key: vaping
+      selection:label: Vaping
+    /selection:listitem[223]:
+      jcr:primaryType: selection:listitem
+      selection:key: ventilation
+      selection:label: Ventilation
+    /selection:listitem[224]:
+      jcr:primaryType: selection:listitem
+      selection:key: video_consultation
+      selection:label: Video consultation
+    /selection:listitem[225]:
+      jcr:primaryType: selection:listitem
+      selection:key: violence
+      selection:label: Violence
+    /selection:listitem[226]:
+      jcr:primaryType: selection:listitem
+      selection:key: virtual_clinics
+      selection:label: Virtual clinics
+    /selection:listitem[227]:
+      jcr:primaryType: selection:listitem
+      selection:key: virus_survival
+      selection:label: Virus survival
+    /selection:listitem[228]:
+      jcr:primaryType: selection:listitem
+      selection:key: visiting
+      selection:label: Visiting
+    /selection:listitem[229]:
+      jcr:primaryType: selection:listitem
+      selection:key: vitamin_c
+      selection:label: Vitamin C
+    /selection:listitem[230]:
+      jcr:primaryType: selection:listitem
+      selection:key: vitamin_d
+      selection:label: Vitamin D
+    /selection:listitem[231]:
+      jcr:primaryType: selection:listitem
+      selection:key: ward_rounds
+      selection:label: Ward rounds
+    /selection:listitem[232]:
+      jcr:primaryType: selection:listitem
+      selection:key: ward_setup
+      selection:label: Ward setup
+    /selection:listitem[233]:
+      jcr:primaryType: selection:listitem
+      selection:key: weaning
+      selection:label: Weaning
+    /selection:listitem[234]:
+      jcr:primaryType: selection:listitem
+      selection:key: well-being
+      selection:label: Well-Being
+    /selection:listitem[235]:
+      jcr:primaryType: selection:listitem
+      selection:key: wellbeing
+      selection:label: Wellbeing

--- a/repository-data/development/src/main/resources/hcm-actions.yaml
+++ b/repository-data/development/src/main/resources/hcm-actions.yaml
@@ -18,4 +18,5 @@ action-lists:
       /content/documents/lks/landing-pages: reload
   - 1.0.18:
       /content/documents/lks/case-studies: reload
-
+  - 1.0.19:
+      /content/documents/lks/search-bank: reload

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/search-bank.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/search-bank.yaml
@@ -11,24 +11,23 @@
     jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
     jcr:uuid: 6534a23e-909a-4e52-a79d-38923f818561
     hippo:name: COVID-19 infection from case notes
-    hippo:versionHistory: bac90aff-4aa4-499d-aa06-0adba07fe766
+    hippo:versionHistory: 57e7f830-51d1-4dfe-8562-cfa5e4d334a9
     /covid-19-infection-from-case-notes[1]:
       jcr:primaryType: hee:searchBank
       jcr:mixinTypes: ['mix:referenceable']
       jcr:uuid: 1e50023b-7d84-4711-b7b5-7618f017a771
-      hee:categories: [prevention]
       hee:completedDate: 2021-05-11T12:32:00+01:00
-      hee:description: Nulla porttitor accumsan tincidunt. Pellentesque in ipsum id
-        orci porta dapibus.
-      hee:details: COVID-19 infection from case notes
-      hee:provider: Derby and Burton Hospitals
+      hee:keyTerms: [environmental_microbiology, medical_records]
+      hee:provider: derby_and_burton_hospitals
       hee:title: COVID-19 infection from case notes
+      hee:topics: [prevention]
       hippo:availability: []
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-05-11T09:08:12.476+01:00
-      hippostdpubwf:lastModificationDate: 2021-05-11T12:32:07.287+01:00
+      hippostdpubwf:lastModificationDate: 2021-06-16T18:55:44.494+01:00
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: cb4c7991-d539-43a0-8080-bfc30ddec1c8
       hippotranslation:locale: en
@@ -54,19 +53,17 @@
       jcr:primaryType: hee:searchBank
       jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
       jcr:uuid: 8c85cb17-dd43-461b-8110-51c34f8c6fe0
-      hee:categories: [prevention]
       hee:completedDate: 2021-05-11T12:32:00+01:00
-      hee:description: Nulla porttitor accumsan tincidunt. Pellentesque in ipsum id
-        orci porta dapibus.
-      hee:details: COVID-19 infection from case notes
-      hee:provider: Derby and Burton Hospitals
+      hee:keyTerms: [environmental_microbiology, medical_records]
+      hee:provider: derby_and_burton_hospitals
       hee:title: COVID-19 infection from case notes
+      hee:topics: [prevention]
       hippo:availability: [preview]
       hippostd:retainable: false
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-05-11T09:08:12.476+01:00
-      hippostdpubwf:lastModificationDate: 2021-05-11T12:32:22.265+01:00
+      hippostdpubwf:lastModificationDate: 2021-06-15T11:52:25.137+01:00
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: cb4c7991-d539-43a0-8080-bfc30ddec1c8
       hippotranslation:locale: en
@@ -92,21 +89,19 @@
       jcr:primaryType: hee:searchBank
       jcr:mixinTypes: ['mix:referenceable']
       jcr:uuid: b87618b1-710a-4997-8882-8046c2ddfc7a
-      hee:categories: [prevention]
       hee:completedDate: 2021-05-11T12:32:00+01:00
-      hee:description: Nulla porttitor accumsan tincidunt. Pellentesque in ipsum id
-        orci porta dapibus.
-      hee:details: COVID-19 infection from case notes
-      hee:provider: Derby and Burton Hospitals
+      hee:keyTerms: [environmental_microbiology, medical_records]
+      hee:provider: derby_and_burton_hospitals
       hee:title: COVID-19 infection from case notes
+      hee:topics: [prevention]
       hippo:availability: [live]
       hippostd:retainable: false
       hippostd:state: published
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-05-11T09:08:12.476+01:00
-      hippostdpubwf:lastModificationDate: 2021-05-11T12:32:22.265+01:00
+      hippostdpubwf:lastModificationDate: 2021-06-15T11:52:25.137+01:00
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2021-05-11T12:32:24.943+01:00
+      hippostdpubwf:publicationDate: 2021-06-15T11:52:27.105+01:00
       hippotranslation:id: cb4c7991-d539-43a0-8080-bfc30ddec1c8
       hippotranslation:locale: en
       /hee:strategyDocument:

--- a/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/pages/search-bank-contentpage.yaml
+++ b/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/pages/search-bank-contentpage.yaml
@@ -6,13 +6,13 @@
     jcr:primaryType: hst:containercomponent
     hippo:identifier: 43b034db-240d-480d-9a69-edea2f3c0cd4
     hst:label: Content Page Main
-    hst:lastmodified: 2021-05-11T10:16:36.550+01:00
+    hst:lastmodified: 2021-06-15T12:14:46.614+01:00
     hst:xtype: hst.vbox
-    /listingpage:
+    /search-bank-listing:
       jcr:primaryType: hst:containeritemcomponent
-      hst:componentclassname: uk.nhs.hee.web.components.CategoryBasedListingPageComponent
+      hst:componentclassname: uk.nhs.hee.web.components.SearchBankListingPageComponent
       hst:iconpath: images/catalog-component-icons/generic-list.svg
-      hst:label: Category based Listing Page [Bulletin & CaseStudy]
+      hst:label: Search Bank Listing Page
       hst:parameternames: [document]
       hst:parametervalues: [listing-pages/search-bank]
-      hst:template: categorybasedlisting-main
+      hst:template: searchbanklisting-main

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
@@ -76,6 +76,9 @@ definitions:
           /casestudylisting-main:
             jcr:primaryType: hst:template
             hst:renderpath: webfile:/freemarker/hee/catalog/casestudylisting-main.ftl
+          /searchbanklisting-main:
+            jcr:primaryType: hst:template
+            hst:renderpath: webfile:/freemarker/hee/catalog/searchbanklisting-main.ftl
         /hst:sitemenus:
           jcr:primaryType: hst:sitemenus
         /hst:sitemapitemhandlers:
@@ -112,7 +115,7 @@ definitions:
               jcr:primaryType: hst:containeritemcomponent
               hst:componentclassname: uk.nhs.hee.web.components.CategoryBasedListingPageComponent
               hst:iconpath: images/catalog-component-icons/generic-list.svg
-              hst:label: Category based Listing Page [Bulletin, Blog & Search Bank]
+              hst:label: Category based Listing Page [Bulletin & Blog]
               hst:template: categorybasedlisting-main
             /blogpost:
               jcr:primaryType: hst:containeritemcomponent
@@ -132,6 +135,12 @@ definitions:
               hst:iconpath: images/catalog-component-icons/generic-list.svg
               hst:label: Case Study Listing Page
               hst:template: casestudylisting-main
+            /search-bank-listing:
+              jcr:primaryType: hst:containeritemcomponent
+              hst:componentclassname: uk.nhs.hee.web.components.SearchBankListingPageComponent
+              hst:iconpath: images/catalog-component-icons/generic-list.svg
+              hst:label: Search Bank Listing Page
+              hst:template: searchbanklisting-main
       /lks:
         jcr:primaryType: hst:configuration
         hst:inheritsfrom: [../common]

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/casestudylisting-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/casestudylisting-main.ftl
@@ -11,6 +11,9 @@
 <#-- @ftlvariable name="pageable" type="org.onehippo.cms7.essentials.components.paging.Pageable" -->
 <#-- @ftlvariable name="item" type="uk.nhs.hee.web.beans.CaseStudy" -->
 <#-- @ftlvariable name="impactGroupMap" type="java.util.Map" -->
+<#-- @ftlvariable name="impactTypesMap" type="java.util.Map" -->
+<#-- @ftlvariable name="sectorMap" type="java.util.Map" -->
+<#-- @ftlvariable name="regionMap" type="java.util.Map" -->
 <#-- @ftlvariable name="selectedImpactGroups" type="java.util.List" -->
 
 <#if document??>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/searchbanklisting-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/searchbanklisting-main.ftl
@@ -9,9 +9,11 @@
 
 <#-- @ftlvariable name="document" type="uk.nhs.hee.web.beans.ListingPage" -->
 <#-- @ftlvariable name="pageable" type="org.onehippo.cms7.essentials.components.paging.Pageable" -->
-<#-- @ftlvariable name="item" type="[uk.nhs.hee.web.beans.Bulletin, uk.nhs.hee.web.beans.BlogPost]" -->
-<#-- @ftlvariable name="categoriesMap" type="java.util.Map" -->
-<#-- @ftlvariable name="selectedCategories" type="java.util.List" -->
+<#-- @ftlvariable name="item" type="uk.nhs.hee.web.beans.SearchBank" -->
+<#-- @ftlvariable name="topicMap" type="java.util.Map" -->
+<#-- @ftlvariable name="keyTermMap" type="java.util.Map" -->
+<#-- @ftlvariable name="providerMap" type="java.util.Map" -->
+<#-- @ftlvariable name="selectedTopics" type="java.util.List" -->
 
 <#if document??>
     <main id="maincontent" role="main" class="nhsuk-main-wrapper" xmlns="http://www.w3.org/1999/html">
@@ -30,10 +32,10 @@
                             <p class="nhsuk-filter__title nhsuk-heading-l">${filtersLabel}</p>
 
                             <div class="nhsuk-filter__groups">
-                                <@fmt.message key="filter.category.label" var="categoryLabel"/>
+                                <@fmt.message key="filter.topic.label" var="topicLabel"/>
 
                                 <div class="nhsuk-filter__group">
-                                    <@checkboxGroup title=categoryLabel name="category" items=categoriesMap selectedItemsList=selectedCategories />
+                                    <@checkboxGroup title=topicLabel name="topic" items=topicMap selectedItemsList=selectedTopics />
                                 </div>
                             </div>
                             <input type="hidden" name="sortByDate" value="${selectedSortOrder}">
@@ -55,8 +57,8 @@
                             <form method="get" class="nhsuk-listing__sort o-flex o-flex--align-center"
                                   action="${pagelink}">
                                 <div class="o-flex__grow">
-                                    <#list selectedCategories as category>
-                                        <input type="hidden" name="category" value="${category}">
+                                    <#list selectedTopics as topic>
+                                        <input type="hidden" name="topic" value="${topic}">
                                     </#list>
 
                                     <@fmt.message key="sort.label" var="sortLabel"/>
@@ -71,11 +73,12 @@
                         </div>
 
                         <#-- Active Filters -->
-                        <#if selectedCategories?has_content>
+                        <#if selectedTopics?has_content>
                             <div class="nhsuk-listing__active-filters nhsuk-u-margin-bottom-5">
-                                <#list selectedCategories as categoryValue>
-                                    <div class="nhsuk-filter-tag nhsuk-tag" data-filter="${categoryValue}">
-                                        <span>${categoriesMap[categoryValue]}</span>
+                                <#list selectedTopics as topic>
+                                    <div class="nhsuk-filter-tag nhsuk-tag" data-filter="${topic
+                                    }">
+                                        <span>${topicMap[topic]}</span>
                                         <@hst.link path='/static/assets/icons/icon-close-white.svg' var="closeIcon"/>
                                         <img class="nhsuk-filter-tag__icon" src="${closeIcon}" alt="Remove" hidden/>
                                     </div>
@@ -86,7 +89,11 @@
 
                         <#if pageable??>
                             <ul class="nhsuk-list nhsuk-list--border">
-                                <@.vars["${document.listingPageType}ListItem"] items=pageable.items categoriesMap=categoriesMap/>
+                                <@.vars["${document.listingPageType}ListItem"]
+                                    items=pageable.items
+                                    topicMap=topicMap
+                                    keyTermMap=keyTermMap
+                                    providerMap=providerMap/>
                             </ul>
                             <#include "../../include/pagination-nhs.ftl">
                         </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
@@ -125,48 +125,53 @@
     </#list>
 </#macro>
 
-<#macro searchbankListItem items categoriesMap>
+<#macro searchbankListItem items topicMap keyTermMap providerMap>
     <#list items as item>
-        <@hst.link var="strategyDocumentURL" hippobean=item.strategyDocument>
-            <@hst.param name="forceDownload" value="true"/>
-        </@hst.link>
+        <#if item.strategyDocument?? && item.strategyDocument.mimeType != 'application/vnd.hippo.blank'>
+            <@hst.link var="strategyDocumentURL" hippobean=item.strategyDocument>
+                <@hst.param name="forceDownload" value="true"/>
+            </@hst.link>
+        <#else>
+            <#assign strategyDocumentURL=''/>
+        </#if>
 
         <h3>
-            <#if strategyDocumentURL??>
+            <#if strategyDocumentURL?has_content>
                 <a href="${strategyDocumentURL}" target="_blank">${item.title}</a>
             <#else>
                 ${item.title}
             </#if>
         </h3>
-        <p>${item.description}</p>
 
         <dl class="nhsuk-summary-list">
-            <#assign categories>${item.categories?map(category -> categoriesMap[category])?join(', ')}</#assign>
-            <#if categories??>
+            <#assign topics>${item.topics?map(topic -> topicMap[topic])?join(', ')}</#assign>
+            <#if topics??>
                 <@fmt.message key="searchbank.topics" var="topicLabel"/>
                 <@listItemRow key="${topicLabel}">
-                    ${categories}
+                    ${topics}
                 </@listItemRow>
             </#if>
 
-            <#if item.details??>
-                <@fmt.message key="searchbank.details" var="detailsLabel"/>
-                <@listItemRow key="${detailsLabel}">
-                    ${item.details}
+            <#assign keyTerms>${item.keyTerms?map(keyTerm -> keyTermMap[keyTerm])?join(', ')}</#assign>
+            <#if keyTerms??>
+                <@fmt.message key="searchbank.key_terms" var="keyTermsLabel"/>
+                <@listItemRow key="${keyTermsLabel}">
+                    ${keyTerms}
                 </@listItemRow>
             </#if>
 
-            <#if strategyDocumentURL??>
+            <#if strategyDocumentURL?has_content>
                 <@fmt.message key="searchbank.strategies" var="strategiesLabel"/>
                 <@listItemRow key="${strategiesLabel}">
                     <a href="${strategyDocumentURL}" target="_blank"><@fmt.message key="searchbank.get_strategy"/></a>
                 </@listItemRow>
             </#if>
 
-            <@hst.link var="searchDocumentURL" hippobean=item.searchDocument>
-                <@hst.param name="forceDownload" value="true"/>
-            </@hst.link>
-            <#if searchDocumentURL??>
+            <#if item.searchDocument?? && item.searchDocument.mimeType != 'application/vnd.hippo.blank'>
+                <@hst.link var="searchDocumentURL" hippobean=item.searchDocument>
+                    <@hst.param name="forceDownload" value="true"/>
+                </@hst.link>
+
                 <@fmt.message key="searchbank.search" var="searchLabel"/>
                 <@listItemRow key="${searchLabel}">
                     <a href="${searchDocumentURL}" target="_blank"><@fmt.message key="searchbank.get_search"/></a>
@@ -180,10 +185,10 @@
                 </@listItemRow>
             </#if>
 
-            <#if item.provider??>
+            <#if item.provider?has_content>
                 <@fmt.message key="searchbank.provider" var="providerLabel"/>
                 <@listItemRow key="${providerLabel}">
-                    ${item.provider}
+                    ${providerMap[item.provider]}
                 </@listItemRow>
             </#if>
         </dl>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/BlogPost.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/BlogPost.java
@@ -36,11 +36,6 @@ public class BlogPost extends BaseDocument {
         return getBean("hee:pageLastNextReview", PageLastNextReview.class);
     }
 
-    @HippoEssentialsGenerated(internalName = "hee:QuickLinks")
-    public QuickLinks getQuickLinks() {
-        return getBean("hee:QuickLinks", QuickLinks.class);
-    }
-
     @HippoEssentialsGenerated(internalName = "hee:publicationDate")
     public Calendar getPublicationDate() {
         return getSingleProperty("hee:publicationDate");

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/SearchBank.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/SearchBank.java
@@ -1,9 +1,10 @@
 package uk.nhs.hee.web.beans;
 
-import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 import org.hippoecm.hst.content.beans.Node;
-import java.util.Calendar;
 import org.hippoecm.hst.content.beans.standard.HippoResourceBean;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+import java.util.Calendar;
 
 @HippoEssentialsGenerated(internalName = "hee:searchBank")
 @Node(jcrType = "hee:searchBank")
@@ -13,24 +14,9 @@ public class SearchBank extends BaseDocument {
         return getSingleProperty("hee:title");
     }
 
-    @HippoEssentialsGenerated(internalName = "hee:description")
-    public String getDescription() {
-        return getSingleProperty("hee:description");
-    }
-
-    @HippoEssentialsGenerated(internalName = "hee:details")
-    public String getDetails() {
-        return getSingleProperty("hee:details");
-    }
-
     @HippoEssentialsGenerated(internalName = "hee:provider")
     public String getProvider() {
         return getSingleProperty("hee:provider");
-    }
-
-    @HippoEssentialsGenerated(internalName = "hee:categories")
-    public String[] getCategories() {
-        return getMultipleProperty("hee:categories");
     }
 
     @HippoEssentialsGenerated(internalName = "hee:strategyDocument")
@@ -46,5 +32,15 @@ public class SearchBank extends BaseDocument {
     @HippoEssentialsGenerated(internalName = "hee:completedDate")
     public Calendar getCompletedDate() {
         return getSingleProperty("hee:completedDate");
+    }
+
+    @HippoEssentialsGenerated(internalName = "hee:topics")
+    public String[] getTopics() {
+        return getMultipleProperty("hee:topics");
+    }
+
+    @HippoEssentialsGenerated(internalName = "hee:keyTerms")
+    public String[] getKeyTerms() {
+        return getMultipleProperty("hee:keyTerms");
     }
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/components/CategoryBasedListingPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/CategoryBasedListingPageComponent.java
@@ -1,22 +1,16 @@
 package uk.nhs.hee.web.components;
 
-import org.apache.commons.lang.StringUtils;
-import org.hippoecm.hst.container.RequestContextProvider;
 import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.exceptions.FilterException;
 import org.hippoecm.hst.content.beans.query.filter.Filter;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
 import org.hippoecm.hst.core.parameters.ParametersInfo;
-import org.onehippo.forge.selection.hst.contentbean.ValueList;
-import org.onehippo.forge.selection.hst.util.SelectionUtil;
 import uk.nhs.hee.web.components.info.ListingPageComponentInfo;
-import uk.nhs.hee.web.constants.HeeNodeType;
+import uk.nhs.hee.web.repository.HEEField;
 import uk.nhs.hee.web.utils.HstUtils;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Base component for all Categories based Listing Pages.
@@ -50,6 +44,6 @@ public class CategoryBasedListingPageComponent extends ListingPageComponent {
      */
     private Filter createCategoryFilter(final HstRequest request, final HstQuery query) throws FilterException {
         final List<String> categoriesFilter = HstUtils.getQueryParameterValues(request, CATEGORY_QUERY_PARAM);
-        return createOrFilter(query, categoriesFilter, HeeNodeType.CATEGORIES);
+        return createOrFilter(query, categoriesFilter, HEEField.CATEGORIES.getName());
     }
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/components/EventListingPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/EventListingPageComponent.java
@@ -11,7 +11,7 @@ import org.hippoecm.repository.util.DateTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.nhs.hee.web.components.info.ListingPageComponentInfo;
-import uk.nhs.hee.web.constants.HeeNodeType;
+import uk.nhs.hee.web.repository.HEEField;
 import uk.nhs.hee.web.utils.HstUtils;
 
 import javax.jcr.NodeIterator;
@@ -59,7 +59,7 @@ public class EventListingPageComponent extends ListingPageComponent {
             final Filter filter = query.createFilter();
             final Calendar yearCalendar = Calendar.getInstance();
             yearCalendar.set(Calendar.YEAR, Integer.parseInt(year));
-            filter.addBetween(HeeNodeType.DATE, yearCalendar, yearCalendar, DateTools.Resolution.YEAR);
+            filter.addBetween(HEEField.DATE.getName(), yearCalendar, yearCalendar, DateTools.Resolution.YEAR);
             baseFilter.addOrFilter(filter);
         }
 
@@ -85,7 +85,7 @@ public class EventListingPageComponent extends ListingPageComponent {
 
             while (eventNodeIterator.hasNext()) {
                 eventYearsSet.add(eventNodeIterator.nextNode()
-                        .getProperty(HeeNodeType.DATE).getDate().get(Calendar.YEAR));
+                        .getProperty(HEEField.DATE.getName()).getDate().get(Calendar.YEAR));
             }
         } catch (final RepositoryException e) {
             LOGGER.error("Caught {} while extracting distinct event years from 'hee:event' documents",

--- a/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageComponent.java
@@ -283,6 +283,18 @@ public abstract class ListingPageComponent extends EssentialsDocumentComponent {
     }
 
     /**
+     * Returns value-list map by identifier ({@code valueListIdentifier}).
+     *
+     * @param valueListIdentifier the value-list identifier whose map needs to be returned.
+     * @return the value-list map by identifier ({@code valueListIdentifier}).
+     */
+    protected Map<String, String> getValueListMapByIdentifier(final String valueListIdentifier) {
+        final ValueList categoriesValueList =
+                SelectionUtil.getValueListByIdentifier(valueListIdentifier, RequestContextProvider.get());
+        return SelectionUtil.valueListAsMap(categoriesValueList);
+    }
+
+    /**
      * Returns requested sort order. Defaults to Descending sort order.
      *
      * @param request the {@link HstRequest} instance.

--- a/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageType.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageType.java
@@ -2,7 +2,7 @@ package uk.nhs.hee.web.components;
 
 import org.apache.commons.lang.StringUtils;
 import org.hippoecm.repository.HippoStdPubWfNodeType;
-import uk.nhs.hee.web.constants.HeeNodeType;
+import uk.nhs.hee.web.repository.HEEField;
 
 /**
  * An enumeration of Listing Page Types and its document types, sort by date field & filter value-list identifier.
@@ -19,7 +19,7 @@ public enum ListingPageType {
             "blog",
             new String[]{"hee:blogPost"},
             Boolean.TRUE,
-            HeeNodeType.PUBLICATION_DATE,
+            HEEField.PUBLICATION_DATE.getName(),
             "blogCategories"),
 
     /**
@@ -49,7 +49,7 @@ public enum ListingPageType {
             "event",
             new String[]{"hee:event"},
             Boolean.TRUE,
-            HeeNodeType.DATE,
+            HEEField.DATE.getName(),
             StringUtils.EMPTY),
 
     /**

--- a/site/components/src/main/java/uk/nhs/hee/web/components/SearchBankListingPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/SearchBankListingPageComponent.java
@@ -13,29 +13,28 @@ import uk.nhs.hee.web.utils.HstUtils;
 import java.util.List;
 
 /**
- * Base component for Case Study Listing Page.
+ * Base component for Search Bank Listing Page.
  */
 @ParametersInfo(type = ListingPageComponentInfo.class)
-public class CaseStudyListingPageComponent extends ListingPageComponent {
+public class SearchBankListingPageComponent extends ListingPageComponent {
 
-    private static final String IMPACT_GROUP_QUERY_PARAM = "impactGroup";
+    private static final String TOPIC_QUERY_PARAM = "topic";
 
     @Override
     public void doBeforeRender(final HstRequest request, final HstResponse response) {
         super.doBeforeRender(request, response);
 
-        request.setModel("selectedImpactGroups", HstUtils.getQueryParameterValues(request, IMPACT_GROUP_QUERY_PARAM));
+        request.setModel("selectedTopics", HstUtils.getQueryParameterValues(request, TOPIC_QUERY_PARAM));
         request.setModel("selectedSortOrder", getSelectedSortOrder(request));
 
-        request.setModel("impactGroupMap", getFilterValueListMap(request));
-        request.setModel("impactTypesMap", getValueListMapByIdentifier("caseStudyImpactTypes"));
-        request.setModel("sectorMap", getValueListMapByIdentifier("caseStudySectors"));
-        request.setModel("regionMap", getValueListMapByIdentifier("regions"));
+        request.setModel("topicMap", getFilterValueListMap(request));
+        request.setModel("keyTermMap", getValueListMapByIdentifier("searchBankKeyTerms"));
+        request.setModel("providerMap", getValueListMapByIdentifier("searchBankProviders"));
     }
 
     @Override
     protected Filter createQueryFilters(final HstRequest request, final HstQuery query) throws FilterException {
-        return createImpactGroupFilter(request, query);
+        return createTopicsFilter(request, query);
     }
 
     /**
@@ -47,8 +46,8 @@ public class CaseStudyListingPageComponent extends ListingPageComponent {
      * @return the {@link Filter} instance built based on the requested impactedGroups.
      * @throws FilterException thrown when an error occurs during Query Filter build.
      */
-    private Filter createImpactGroupFilter(final HstRequest request, final HstQuery query) throws FilterException {
-        final List<String> impactGroupFilter = HstUtils.getQueryParameterValues(request, IMPACT_GROUP_QUERY_PARAM);
-        return createOrFilter(query, impactGroupFilter, HEEField.IMPACT_GROUP.getName());
+    private Filter createTopicsFilter(final HstRequest request, final HstQuery query) throws FilterException {
+        final List<String> impactGroupFilter = HstUtils.getQueryParameterValues(request, TOPIC_QUERY_PARAM);
+        return createOrFilter(query, impactGroupFilter, HEEField.TOPICS.getName());
     }
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/constants/HeeNodeType.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/constants/HeeNodeType.java
@@ -2,8 +2,4 @@ package uk.nhs.hee.web.constants;
 
 public interface HeeNodeType {
     String HEE_NAMESPACE = "hee";
-    String CATEGORIES = "hee:categories";
-    String IMPACT_GROUP = "hee:impactGroup";
-    String PUBLICATION_DATE = "hee:publicationDate";
-    String DATE = "hee:date";
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/repository/HEEField.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/repository/HEEField.java
@@ -8,7 +8,33 @@ public enum HEEField {
     /**
      * {@code listingPageType} field/property.
      */
-    LISTING_TYPE("hee:listingPageType");
+    LISTING_TYPE("hee:listingPageType"),
+
+    /**
+     * {@code impactGroup} field/property.
+     */
+    IMPACT_GROUP("hee:impactGroup"),
+
+    /**
+     * {@code topics} field/property.
+     */
+    TOPICS("hee:topics"),
+
+    /**
+     * {@code categories} field/property.
+     */
+    CATEGORIES("hee:categories"),
+
+    /**
+     * {@code publicationDate} field/property.
+     */
+    PUBLICATION_DATE("hee:publicationDate"),
+
+    /**
+     * {@code date} field/property.
+     */
+    DATE("hee:date");
+
 
     private final String name;
 
@@ -27,6 +53,6 @@ public enum HEEField {
      * @return the name of HEE field/property.
      */
     public String getName() {
-        return name;
+        return this.name;
     }
 }

--- a/site/components/src/main/resources/META-INF/hst-assembly/overrides/valueListManager.xml
+++ b/site/components/src/main/resources/META-INF/hst-assembly/overrides/valueListManager.xml
@@ -26,6 +26,8 @@
         <entry key="caseStudySectors" value="/content/documents/administration/valuelists/kls/casestudysectors"/>
         <entry key="regions" value="/content/documents/administration/valuelists/kls/regions"/>
         <entry key="searchBankTopics" value="/content/documents/administration/valuelists/kls/searchbanktopics"/>
+        <entry key="searchBankKeyTerms" value="/content/documents/administration/valuelists/kls/searchbankkeyterms"/>
+        <entry key="searchBankProviders" value="/content/documents/administration/valuelists/kls/searchbankproviders"/>
       </map>
     </constructor-arg>
   </bean>


### PR DESCRIPTION
- SearchBank CMS fields alignment with migration JSON data. The following field amendments have been made:
  - `description` field has been removed.
  - `details` field has been removed.
  - `categories` field has been replaced with `topics` field.
  - Amended `provider` field to use `/content/documents/administration/valuelists/kls/searchbankproivders` value-list (which was previously using a Text[Area] field).
  - `keyTerms` field has been added which in turn uses `/content/documents/administration/valuelists/kls/searchbankkeyterms` value-list.
- Separate `Search Bank Listing Page` component build for SearchBank Listing.
- SearchBank listing page/FE update based on CMS field amendments.

The first part of the HEE-271 ticket i.e. Search Bank data migration/import has been dealt separately as part of a separate repository https://github.com/Manifesto-Digital/hee-search-bank-migration containing python scripts to build brXM search bank data migration/import (YAML) files. Suggest to review this repository as well. Thank you!

Note that https://github.com/Manifesto-Digital/hee-search-bank-migration repo currently doesn't produces import for `Key Terms` (`hee:keyTerms`) as the corresponding migration data isn't consistent. Fyi - @MattBrooksManifesto is currently working on pulling a consistent `Key Terms` data and a commit could be expected on this PR with updated `/content/documents/administration/valuelists/kls/searchbankkeyterms` value-list when the data is available.