### PR TITLE
HEE-281: kfh.libraryservices.nhs.uk domain level redirect setup

### DIFF
--- a/repository-data/application/src/main/resources/hcm-actions.yaml
+++ b/repository-data/application/src/main/resources/hcm-actions.yaml
@@ -19,3 +19,5 @@ action-lists:
       /content/documents/administration/valuelists/kls/searchbanktopics: reload
   - 1.0.18:
       /content/urlrewriter/kls/searchtosearchresultsredirect: reload
+  - 1.0.19:
+      /content/urlrewriter/kls/kfhtolksredirects: reload

--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls/kfhtolksredirects.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls/kfhtolksredirects.yaml
@@ -1,9 +1,10 @@
 /content/urlrewriter/kls/kfhtolksredirects:
+  .meta:order-before: hometoknowledgestaffredirect
   jcr:primaryType: hippo:handle
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: 3e5c8fac-e733-40e0-8151-f78e9d2253de
   hippo:name: KFHToLKSRedirects
-  hippo:versionHistory: 7536197e-e284-46dd-a3f1-8148ba92b71a
+  hippo:versionHistory: b00ff53a-2848-448c-8eb2-4f6f50e93920
   /kfhtolksredirects[1]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:versionable']
@@ -13,9 +14,15 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:07:54.302+01:00
-    hippostdpubwf:lastModificationDate: 2021-06-23T15:03:02.060+01:00
+    hippostdpubwf:lastModificationDate: 2021-07-01T10:19:53.417+01:00
     hippostdpubwf:lastModifiedBy: admin
-    urlrewriter:rule: "<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
+    urlrewriter:rule: "<rule>\r\n  <name>kfh.libraryservices.nhs.uk to library.hee.nhs.uk\
+      \ Domain Level Redirect</name>\r\n  <note>This redirect added here intentionally\
+      \ in order to ensure that the domain level redirect happens first before any\
+      \ of the following redirects are processed</note>\r\n  <condition name=\"host\"\
+      \ operator=\"equal\">kfh.libraryservices.nhs.uk</condition>\r\n  <from>^(.*)$</from>\r\
+      \n  <to type=\"permanent-redirect\" last=\"true\">https://library.hee.nhs.uk$1</to>\r\
+      \n</rule>\r\n\r\n<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
       \n  <from>^/database/?$</from>\r\n  <to type=\"permanent-redirect\" last=\"\
       true\">/quality-and-impact/value-and-impact/case-studies-impact</to>\r\n</rule>\r\
       \n<rule>\r\n  <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
@@ -1683,9 +1690,15 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:07:54.302+01:00
-    hippostdpubwf:lastModificationDate: 2021-06-23T15:02:58.576+01:00
+    hippostdpubwf:lastModificationDate: 2021-07-01T10:19:46.754+01:00
     hippostdpubwf:lastModifiedBy: admin
-    urlrewriter:rule: "<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
+    urlrewriter:rule: "<rule>\r\n  <name>kfh.libraryservices.nhs.uk to library.hee.nhs.uk\
+      \ Domain Level Redirect</name>\r\n  <note>This redirect added here intentionally\
+      \ in order to ensure that the domain level redirect happens first before any\
+      \ of the following redirects are processed</note>\r\n  <condition name=\"host\"\
+      \ operator=\"equal\">kfh.libraryservices.nhs.uk</condition>\r\n  <from>^(.*)$</from>\r\
+      \n  <to type=\"permanent-redirect\" last=\"true\">https://library.hee.nhs.uk$1</to>\r\
+      \n</rule>\r\n\r\n<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
       \n  <from>^/database/?$</from>\r\n  <to type=\"permanent-redirect\" last=\"\
       true\">/quality-and-impact/value-and-impact/case-studies-impact</to>\r\n</rule>\r\
       \n<rule>\r\n  <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
@@ -3353,10 +3366,16 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:07:54.302+01:00
-    hippostdpubwf:lastModificationDate: 2021-06-23T15:03:02.060+01:00
+    hippostdpubwf:lastModificationDate: 2021-07-01T10:19:53.417+01:00
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2021-06-23T15:03:06.867+01:00
-    urlrewriter:rule: "<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
+    hippostdpubwf:publicationDate: 2021-07-01T10:19:55.845+01:00
+    urlrewriter:rule: "<rule>\r\n  <name>kfh.libraryservices.nhs.uk to library.hee.nhs.uk\
+      \ Domain Level Redirect</name>\r\n  <note>This redirect added here intentionally\
+      \ in order to ensure that the domain level redirect happens first before any\
+      \ of the following redirects are processed</note>\r\n  <condition name=\"host\"\
+      \ operator=\"equal\">kfh.libraryservices.nhs.uk</condition>\r\n  <from>^(.*)$</from>\r\
+      \n  <to type=\"permanent-redirect\" last=\"true\">https://library.hee.nhs.uk$1</to>\r\
+      \n</rule>\r\n\r\n<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
       \n  <from>^/database/?$</from>\r\n  <to type=\"permanent-redirect\" last=\"\
       true\">/quality-and-impact/value-and-impact/case-studies-impact</to>\r\n</rule>\r\
       \n<rule>\r\n  <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
@@ -21,3 +21,15 @@ definitions:
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/lks
+        /libraryservices:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:virtualhost
+          /kfh:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:virtualhost
+            /hst:root:
+              .meta:residual-child-node-category: content
+              jcr:primaryType: hst:mount
+              hst:homepage: root
+              hst:locale: en
+              hst:mountpoint: /hst:hee/hst:sites/lks


### PR DESCRIPTION
- Prod virtual host setup for `kfh.libraryservices.nhs.uk`.
- Rewrite rule to perform `kfh.libraryservices.nhs.uk` domain level [301] redirect to `library.hee.nhs.uk`.

Note that the following domain level redirect has been added part of existing rewrite rule document `/content/urlrewriter/kls/kfhtolksredirects` and as the first rule in order to ensure that it is processed first before the other old to new website redirects are processed.
```
<rule>
  <name>kfh.libraryservices.nhs.uk to library.hee.nhs.uk Domain Level Redirect</name>
  <note>This redirect added here intentionally in order to ensure that the domain level redirect happens first before any of the following redirects are processed</note>
  <condition name="host" operator="equal">kfh.libraryservices.nhs.uk</condition>
  <from>^(.*)$</from>
  <to type="permanent-redirect" last="true">https://library.hee.nhs.uk$1</to>
</rule>
```