### PR TITLE
HEE-287 & HEE-288: Dental & Digital Transformation channel setup

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental-assets-and-gallery-readwrite.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental-assets-and-gallery-readwrite.yaml
@@ -1,0 +1,57 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-dental-assets-and-gallery-readwrite:
+      jcr:primaryType: hipposys:domain
+      /assets-domain:
+        jcr:primaryType: hipposys:domainrule
+        /documents-only:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: hippo:availability
+          hipposys:type: String
+          hipposys:value: live
+        /non-publishable:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: nodetype
+          hipposys:type: String
+          hipposys:value: hippostd:publishable
+        /dental-assets-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/assets/dental
+      /rewrite:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [dental-author, dental-editor]
+        hipposys:role: readwrite
+        hipposys:users:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: []
+      /gallery-domain:
+        jcr:primaryType: hipposys:domainrule
+        /documents-only:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: hippo:availability
+          hipposys:type: String
+          hipposys:value: live
+        /non-publishable:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: nodetype
+          hipposys:type: String
+          hipposys:value: hippostd:publishable
+        /dental-gallery-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/gallery/dental

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental.yaml
@@ -1,0 +1,67 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-dental:
+      jcr:primaryType: hipposys:domain
+      /content-domain:
+        jcr:primaryType: hipposys:domainrule
+        /dental-content-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/dental
+      /author:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [dental-author]
+        hipposys:role: author
+        hipposys:users:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: []
+      /editor:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [dental-editor]
+        hipposys:role: editor
+        hipposys:users:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: []
+      /gallery-domain:
+        jcr:primaryType: hipposys:domainrule
+        /dental-gallery-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/gallery/dental
+      /assets-domain:
+        jcr:primaryType: hipposys:domainrule
+        /dental-assets-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/assets/dental
+      /readonly:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [dental-reader]
+        hipposys:role: readonly
+        hipposys:users:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: []

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation-assets-and-gallery-readwrite.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation-assets-and-gallery-readwrite.yaml
@@ -1,0 +1,57 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-digital-transformation-assets-and-gallery-readwrite:
+      jcr:primaryType: hipposys:domain
+      /assets-domain:
+        jcr:primaryType: hipposys:domainrule
+        /documents-only:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: hippo:availability
+          hipposys:type: String
+          hipposys:value: live
+        /non-publishable:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: nodetype
+          hipposys:type: String
+          hipposys:value: hippostd:publishable
+        /digital-transformation-assets-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/assets/digital-transformation
+      /rewrite:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [digital-transformation-author, digital-transformation-editor]
+        hipposys:role: readwrite
+        hipposys:users:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: []
+      /gallery-domain:
+        jcr:primaryType: hipposys:domainrule
+        /documents-only:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: hippo:availability
+          hipposys:type: String
+          hipposys:value: live
+        /non-publishable:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: nodetype
+          hipposys:type: String
+          hipposys:value: hippostd:publishable
+        /digital-transformation-gallery-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/gallery/digital-transformation

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation.yaml
@@ -1,0 +1,67 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-digital-transformation:
+      jcr:primaryType: hipposys:domain
+      /content-domain:
+        jcr:primaryType: hipposys:domainrule
+        /digital-transformation-content-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/digital-transformation
+      /author:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [digital-transformation-author]
+        hipposys:role: author
+        hipposys:users:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: []
+      /editor:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [digital-transformation-editor]
+        hipposys:role: editor
+        hipposys:users:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: []
+      /gallery-domain:
+        jcr:primaryType: hipposys:domainrule
+        /digital-transformation-gallery-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/gallery/digital-transformation
+      /assets-domain:
+        jcr:primaryType: hipposys:domainrule
+        /digital-transformation-assets-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/assets/digital-transformation
+      /readonly:
+        jcr:primaryType: hipposys:authrole
+        hipposys:groups:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: [digital-transformation-reader]
+        hipposys:role: readonly
+        hipposys:users:
+          .meta:category: system
+          .meta:add-new-system-values: true
+          type: string
+          value: []

--- a/repository-data/application/src/main/resources/hcm-config/configuration/groups/dental-author.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/groups/dental-author.yaml
@@ -1,0 +1,16 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:groups/dental-author:
+      jcr:primaryType: hipposys:group
+      hipposys:members:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: []
+      hipposys:securityprovider: internal
+      hipposys:userroles:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: [xm.cms.user, xm.content.user, xm.channel.user, xm.channel.viewer,
+          xm.dashboard.user]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/groups/dental-editor.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/groups/dental-editor.yaml
@@ -1,0 +1,16 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:groups/dental-editor:
+      jcr:primaryType: hipposys:group
+      hipposys:members:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: []
+      hipposys:securityprovider: internal
+      hipposys:userroles:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: [xm.cms.user, xm.content.user, xm.channel.user, xm.channel.webmaster,
+          xm.dashboard.user]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/groups/dental-reader.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/groups/dental-reader.yaml
@@ -1,0 +1,15 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:groups/dental-reader:
+      jcr:primaryType: hipposys:group
+      hipposys:members:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: []
+      hipposys:securityprovider: internal
+      hipposys:userroles:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: [xm.cms.user, xm.content.user]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/groups/digital-transformation-author.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/groups/digital-transformation-author.yaml
@@ -1,0 +1,16 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:groups/digital-transformation-author:
+      jcr:primaryType: hipposys:group
+      hipposys:members:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: []
+      hipposys:securityprovider: internal
+      hipposys:userroles:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: [xm.cms.user, xm.content.user, xm.channel.user, xm.channel.viewer,
+          xm.dashboard.user]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/groups/digital-transformation-editor.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/groups/digital-transformation-editor.yaml
@@ -1,0 +1,16 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:groups/digital-transformation-editor:
+      jcr:primaryType: hipposys:group
+      hipposys:members:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: []
+      hipposys:securityprovider: internal
+      hipposys:userroles:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: [xm.cms.user, xm.content.user, xm.channel.user, xm.channel.webmaster,
+          xm.dashboard.user]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/groups/digital-transformation-reader.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/groups/digital-transformation-reader.yaml
@@ -1,0 +1,15 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:groups/digital-transformation-reader:
+      jcr:primaryType: hipposys:group
+      hipposys:members:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: []
+      hipposys:securityprovider: internal
+      hipposys:userroles:
+        .meta:category: system
+        .meta:add-new-system-values: true
+        type: string
+        value: [xm.cms.user, xm.content.user]

--- a/repository-data/application/src/main/resources/hcm-content/content/assets/dental.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/assets/dental.yaml
@@ -1,8 +1,7 @@
-/content/assets/lks:
-  .meta:order-before: digital-transformation
+/content/assets/dental:
   jcr:primaryType: hippogallery:stdAssetGallery
   jcr:mixinTypes: ['hippo:named', 'mix:versionable']
-  jcr:uuid: ea11ee3a-e081-40e1-acb3-5214de1f1d1f
-  hippo:name: KLS
+  jcr:uuid: 9f508169-b36c-416c-bcd9-fe0e0dab6217
+  hippo:name: Dental
   hippostd:foldertype: [new-file-folder]
   hippostd:gallerytype: ['hippogallery:exampleAssetSet']

--- a/repository-data/application/src/main/resources/hcm-content/content/assets/digital-transformation.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/assets/digital-transformation.yaml
@@ -1,8 +1,8 @@
-/content/assets/lks:
-  .meta:order-before: digital-transformation
+/content/assets/digital-transformation:
+  .meta:order-before: dental
   jcr:primaryType: hippogallery:stdAssetGallery
   jcr:mixinTypes: ['hippo:named', 'mix:versionable']
-  jcr:uuid: ea11ee3a-e081-40e1-acb3-5214de1f1d1f
-  hippo:name: KLS
+  jcr:uuid: 4fa4d760-d73b-4e58-af88-1a32005ee6d4
+  hippo:name: Digital Transformation
   hippostd:foldertype: [new-file-folder]
   hippostd:gallerytype: ['hippogallery:exampleAssetSet']

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/dental.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/dental.yaml
@@ -1,0 +1,8 @@
+/content/documents/dental:
+  jcr:primaryType: hippostd:folder
+  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:referenceable']
+  jcr:uuid: e52c098d-4c1e-40df-a48c-5422146ea3d5
+  hippo:name: Dental
+  hippostd:foldertype: [new-translated-folder, new-document]
+  hippotranslation:id: 0ba2f232-f88b-4646-b746-1366b35b201c
+  hippotranslation:locale: en

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/digital-transformation.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/digital-transformation.yaml
@@ -1,0 +1,9 @@
+/content/documents/digital-transformation:
+  .meta:order-before: dental
+  jcr:primaryType: hippostd:folder
+  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:referenceable']
+  jcr:uuid: cc02274c-9ab2-4895-bd0d-ceaac3ba0e40
+  hippo:name: Digital Transformation
+  hippostd:foldertype: [new-translated-folder, new-document]
+  hippotranslation:id: 1aafd465-eb27-45e9-bef0-4417421ab281
+  hippotranslation:locale: en

--- a/repository-data/application/src/main/resources/hcm-content/content/gallery/dental.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/gallery/dental.yaml
@@ -1,0 +1,7 @@
+/content/gallery/dental:
+  jcr:primaryType: hippogallery:stdImageGallery
+  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
+  jcr:uuid: 0df5aaae-9e24-42ae-9b93-395428b72135
+  hippo:name: Dental
+  hippostd:foldertype: [new-image-folder]
+  hippostd:gallerytype: ['hee:imagesetWithCaption']

--- a/repository-data/application/src/main/resources/hcm-content/content/gallery/digital-transformation.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/gallery/digital-transformation.yaml
@@ -1,0 +1,8 @@
+/content/gallery/digital-transformation:
+  .meta:order-before: dental
+  jcr:primaryType: hippogallery:stdImageGallery
+  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
+  jcr:uuid: 337b9ab4-b136-49e8-a767-54445f36fbd0
+  hippo:name: Digital Transformation
+  hippostd:foldertype: [new-image-folder]
+  hippostd:gallerytype: ['hee:imagesetWithCaption']

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/dental/home.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/dental/home.yaml
@@ -1,0 +1,88 @@
+/content/documents/dental/home:
+  jcr:primaryType: hippo:handle
+  jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
+  jcr:uuid: 1e0005cc-794d-47cb-9f8e-a1a0729de8b9
+  hippo:name: Home
+  hippo:versionHistory: 8d326d03-0553-42a5-b88f-7180affd3a9e
+  /home[1]:
+    jcr:primaryType: hee:HomePage
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: f7ce909f-0300-4004-969c-edff9fb33004
+    hippo:availability: []
+    hippostd:retainable: false
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2021-07-13T15:47:59.693+01:00
+    hippostdpubwf:lastModificationDate: 2021-07-13T15:47:59.693+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 70bca06c-b94f-46b8-83af-663da5696850
+    hippotranslation:locale: en
+    /hee:HeroSection:
+      jcr:primaryType: hee:HeroSection
+      hee:header: Dental Header
+      hee:text: Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Curabitur
+        non nulla sit amet nisl tempus convallis quis ac lectus. Vestibulum ac diam
+        sit amet quam vehicula elementum sed sit amet dui.
+    /hee:contentBlocks:
+      jcr:primaryType: hippostd:html
+      hippostd:content: |-
+        <p>Quisque velit nisi, pretium ut lacinia in, elementum id enim. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Nulla quis lorem ut libero malesuada feugiat.</p>
+
+        <p>Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Nulla porttitor accumsan tincidunt.</p>
+
+        <p>Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  /home[2]:
+    jcr:primaryType: hee:HomePage
+    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+    jcr:uuid: 25c306f6-1690-46e5-94da-4eaf26d083c5
+    hippo:availability: [preview]
+    hippostd:retainable: false
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2021-07-13T15:47:59.693+01:00
+    hippostdpubwf:lastModificationDate: 2021-07-13T15:48:43.133+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 70bca06c-b94f-46b8-83af-663da5696850
+    hippotranslation:locale: en
+    /hee:HeroSection:
+      jcr:primaryType: hee:HeroSection
+      hee:header: Dental Header
+      hee:text: Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Curabitur
+        non nulla sit amet nisl tempus convallis quis ac lectus. Vestibulum ac diam
+        sit amet quam vehicula elementum sed sit amet dui.
+    /hee:contentBlocks:
+      jcr:primaryType: hippostd:html
+      hippostd:content: |-
+        <p>Quisque velit nisi, pretium ut lacinia in, elementum id enim. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Nulla quis lorem ut libero malesuada feugiat.</p>
+
+        <p>Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Nulla porttitor accumsan tincidunt.</p>
+
+        <p>Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  /home[3]:
+    jcr:primaryType: hee:HomePage
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: 590c77ed-22b1-4618-a7ee-8764980c79a1
+    hippo:availability: [live]
+    hippostd:retainable: false
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2021-07-13T15:47:59.693+01:00
+    hippostdpubwf:lastModificationDate: 2021-07-13T15:48:43.133+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2021-07-13T15:48:44.921+01:00
+    hippotranslation:id: 70bca06c-b94f-46b8-83af-663da5696850
+    hippotranslation:locale: en
+    /hee:HeroSection:
+      jcr:primaryType: hee:HeroSection
+      hee:header: Dental Header
+      hee:text: Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Curabitur
+        non nulla sit amet nisl tempus convallis quis ac lectus. Vestibulum ac diam
+        sit amet quam vehicula elementum sed sit amet dui.
+    /hee:contentBlocks:
+      jcr:primaryType: hippostd:html
+      hippostd:content: |-
+        <p>Quisque velit nisi, pretium ut lacinia in, elementum id enim. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Nulla quis lorem ut libero malesuada feugiat.</p>
+
+        <p>Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Nulla porttitor accumsan tincidunt.</p>
+
+        <p>Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/digital-transformation/home.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/digital-transformation/home.yaml
@@ -1,0 +1,88 @@
+/content/documents/digital-transformation/home:
+  jcr:primaryType: hippo:handle
+  jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
+  jcr:uuid: 083e6069-d0c9-4fb8-865a-af0fbf730116
+  hippo:name: Home
+  hippo:versionHistory: 74a34943-051b-414e-a417-7dcd76a5d5b3
+  /home[1]:
+    jcr:primaryType: hee:HomePage
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: b3528681-b9d3-4801-810b-8cab91b2d4bc
+    hippo:availability: []
+    hippostd:retainable: false
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2021-07-13T15:46:57.349+01:00
+    hippostdpubwf:lastModificationDate: 2021-07-13T15:48:06.792+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: cb459d2a-db6f-47c8-a975-e8a76d004777
+    hippotranslation:locale: en
+    /hee:HeroSection:
+      jcr:primaryType: hee:HeroSection
+      hee:header: Digital Transformation Header
+      hee:text: Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+        Quisque velit nisi, pretium ut lacinia in, elementum id enim. Praesent sapien
+        massa, convallis a pellentesque nec, egestas non nisi.
+    /hee:contentBlocks:
+      jcr:primaryType: hippostd:html
+      hippostd:content: |-
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Cras ultricies ligula sed magna dictum porta.</p>
+
+        <p>Nulla porttitor accumsan tincidunt. Sed porttitor lectus nibh. Donec rutrum congue leo eget malesuada.</p>
+
+        <p>Sed porttitor lectus nibh. Cras ultricies ligula sed magna dictum porta. Donec rutrum congue leo eget malesuada.</p>
+  /home[2]:
+    jcr:primaryType: hee:HomePage
+    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+    jcr:uuid: cd839266-fea0-4df7-9cb9-9c1a3a854e76
+    hippo:availability: [preview]
+    hippostd:retainable: false
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2021-07-13T15:46:57.349+01:00
+    hippostdpubwf:lastModificationDate: 2021-07-13T15:48:22.039+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: cb459d2a-db6f-47c8-a975-e8a76d004777
+    hippotranslation:locale: en
+    /hee:HeroSection:
+      jcr:primaryType: hee:HeroSection
+      hee:header: Digital Transformation Header
+      hee:text: Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+        Quisque velit nisi, pretium ut lacinia in, elementum id enim. Praesent sapien
+        massa, convallis a pellentesque nec, egestas non nisi.
+    /hee:contentBlocks:
+      jcr:primaryType: hippostd:html
+      hippostd:content: |-
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Cras ultricies ligula sed magna dictum porta.</p>
+
+        <p>Nulla porttitor accumsan tincidunt. Sed porttitor lectus nibh. Donec rutrum congue leo eget malesuada.</p>
+
+        <p>Sed porttitor lectus nibh. Cras ultricies ligula sed magna dictum porta. Donec rutrum congue leo eget malesuada.</p>
+  /home[3]:
+    jcr:primaryType: hee:HomePage
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: 9668d3b4-f1cb-48b2-a23b-666aa7e041f9
+    hippo:availability: [live]
+    hippostd:retainable: false
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2021-07-13T15:46:57.349+01:00
+    hippostdpubwf:lastModificationDate: 2021-07-13T15:48:22.039+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2021-07-13T15:48:23.541+01:00
+    hippotranslation:id: cb459d2a-db6f-47c8-a975-e8a76d004777
+    hippotranslation:locale: en
+    /hee:HeroSection:
+      jcr:primaryType: hee:HeroSection
+      hee:header: Digital Transformation Header
+      hee:text: Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+        Quisque velit nisi, pretium ut lacinia in, elementum id enim. Praesent sapien
+        massa, convallis a pellentesque nec, egestas non nisi.
+    /hee:contentBlocks:
+      jcr:primaryType: hippostd:html
+      hippostd:content: |-
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Cras ultricies ligula sed magna dictum porta.</p>
+
+        <p>Nulla porttitor accumsan tincidunt. Sed porttitor lectus nibh. Donec rutrum congue leo eget malesuada.</p>
+
+        <p>Sed porttitor lectus nibh. Cras ultricies ligula sed magna dictum porta. Donec rutrum congue leo eget malesuada.</p>

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
@@ -169,3 +169,9 @@ definitions:
       /lks:
         jcr:primaryType: hst:configuration
         hst:inheritsfrom: [../common]
+      /digital-transformation:
+        jcr:primaryType: hst:configuration
+        hst:inheritsfrom: [../common]
+      /dental:
+        jcr:primaryType: hst:configuration
+        hst:inheritsfrom: [../common]

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/components.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/components.yaml
@@ -1,0 +1,4 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/dental/hst:components:
+      jcr:primaryType: hst:components

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/pages.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/pages.yaml
@@ -1,0 +1,4 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/dental/hst:pages:
+      jcr:primaryType: hst:pages

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/sitemap.yaml
@@ -1,0 +1,4 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/dental/hst:sitemap:
+      jcr:primaryType: hst:sitemap

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/workspace.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/workspace.yaml
@@ -1,0 +1,37 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/dental/hst:workspace:
+      jcr:primaryType: hst:workspace
+      /hst:containers:
+        jcr:primaryType: hst:containercomponentfolder
+        /base:
+          jcr:primaryType: hst:containercomponentfolder
+          /top:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:containercomponent
+            hippo:identifier: d8ce1687-d3bc-460b-9e09-ccf6ef02040a
+            hst:label: Top
+            hst:xtype: hst.vbox
+          /footer:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:containercomponent
+            hippo:identifier: bf49dd94-e55c-4804-9b4f-10ca04a3d8cc
+            hst:label: Footer
+            hst:xtype: hst.vbox
+        /pagenotfound:
+          jcr:primaryType: hst:containercomponentfolder
+          /main:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:containercomponent
+            hippo:identifier: 2673ae05-b8f0-4a0f-a844-b8c7ce014865
+            hst:label: Page-Not-Found Main
+            hst:xtype: hst.vbox
+      /hst:sitemenus:
+        jcr:primaryType: hst:sitemenus
+        /main:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:sitemenu
+          hst:lastmodified: 2021-02-23T14:29:13.810+07:00
+        /footer:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:sitemenu

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/workspace/channel.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/workspace/channel.yaml
@@ -1,0 +1,12 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/dental/hst:workspace/hst:channel:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:channel
+      hst:channelinfoclass: uk.nhs.hee.web.channels.WebsiteInfo
+      hst:defaultdevice: default
+      hst:devices: []
+      hst:lastmodified: 2021-07-13T16:34:24.381+01:00
+      hst:lastmodifiedby: admin
+      hst:name: Dental
+      hst:type: website

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/workspace/pages.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/workspace/pages.yaml
@@ -1,0 +1,5 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/dental/hst:workspace/hst:pages:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:pages

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/workspace/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/dental/workspace/sitemap.yaml
@@ -1,0 +1,5 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/dental/hst:workspace/hst:sitemap:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:sitemap

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/components.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/components.yaml
@@ -1,0 +1,4 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/digital-transformation/hst:components:
+      jcr:primaryType: hst:components

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/pages.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/pages.yaml
@@ -1,0 +1,4 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/digital-transformation/hst:pages:
+      jcr:primaryType: hst:pages

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/sitemap.yaml
@@ -1,0 +1,4 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/digital-transformation/hst:sitemap:
+      jcr:primaryType: hst:sitemap

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/workspace.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/workspace.yaml
@@ -1,0 +1,37 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/digital-transformation/hst:workspace:
+      jcr:primaryType: hst:workspace
+      /hst:containers:
+        jcr:primaryType: hst:containercomponentfolder
+        /base:
+          jcr:primaryType: hst:containercomponentfolder
+          /top:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:containercomponent
+            hippo:identifier: d8ce1687-d3bc-460b-9e09-ccf6ef02040a
+            hst:label: Top
+            hst:xtype: hst.vbox
+          /footer:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:containercomponent
+            hippo:identifier: bf49dd94-e55c-4804-9b4f-10ca04a3d8cc
+            hst:label: Footer
+            hst:xtype: hst.vbox
+        /pagenotfound:
+          jcr:primaryType: hst:containercomponentfolder
+          /main:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:containercomponent
+            hippo:identifier: 2673ae05-b8f0-4a0f-a844-b8c7ce014865
+            hst:label: Page-Not-Found Main
+            hst:xtype: hst.vbox
+      /hst:sitemenus:
+        jcr:primaryType: hst:sitemenus
+        /main:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:sitemenu
+          hst:lastmodified: 2021-02-23T14:29:13.810+07:00
+        /footer:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:sitemenu

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/workspace/channel.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/workspace/channel.yaml
@@ -1,0 +1,12 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/digital-transformation/hst:workspace/hst:channel:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:channel
+      hst:channelinfoclass: uk.nhs.hee.web.channels.WebsiteInfo
+      hst:defaultdevice: default
+      hst:devices: []
+      hst:lastmodified: 2021-07-13T16:34:41.325+01:00
+      hst:lastmodifiedby: admin
+      hst:name: Digital Transformation
+      hst:type: website

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/workspace/pages.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/workspace/pages.yaml
@@ -1,0 +1,5 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/digital-transformation/hst:workspace/hst:pages:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:pages

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/workspace/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/digital-transformation/workspace/sitemap.yaml
@@ -1,0 +1,5 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/digital-transformation/hst:workspace/hst:sitemap:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:sitemap

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts.yaml
@@ -13,3 +13,11 @@ definitions:
           hst:homepage: root
           hst:mountpoint: /hst:hee/hst:sites/lks
           hst:locale: en
+          /digital-transformation:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:mount
+            hst:mountpoint: /hst:hee/hst:sites/digital-transformation
+          /dental:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:mount
+            hst:mountpoint: /hst:hee/hst:sites/dental

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev-brcloud/io.yaml
@@ -18,3 +18,9 @@ definitions:
             hst:homepage: root
             hst:mountpoint: /hst:hee/hst:sites/lks
             hst:locale: en
+            /dental:
+              jcr:primaryType: hst:mount
+              hst:mountpoint: /hst:hee/hst:sites/dental
+            /digital-transformation:
+              jcr:primaryType: hst:mount
+              hst:mountpoint: /hst:hee/hst:sites/digital-transformation

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/io.yaml
@@ -18,3 +18,9 @@ definitions:
             hst:homepage: root
             hst:locale: en
             hst:mountpoint: /hst:hee/hst:sites/lks
+            /dental:
+              jcr:primaryType: hst:mount
+              hst:mountpoint: /hst:hee/hst:sites/dental
+            /digital-transformation:
+              jcr:primaryType: hst:mount
+              hst:mountpoint: /hst:hee/hst:sites/digital-transformation

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
@@ -21,6 +21,24 @@ definitions:
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/lks
+          /dental:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:virtualhost
+            /hst:root:
+              .meta:residual-child-node-category: content
+              jcr:primaryType: hst:mount
+              hst:homepage: root
+              hst:locale: en
+              hst:mountpoint: /hst:hee/hst:sites/dental
+          /digital-transformation:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:virtualhost
+            /hst:root:
+              .meta:residual-child-node-category: content
+              jcr:primaryType: hst:mount
+              hst:homepage: root
+              hst:locale: en
+              hst:mountpoint: /hst:hee/hst:sites/digital-transformation
         /libraryservices:
           .meta:residual-child-node-category: content
           jcr:primaryType: hst:virtualhost

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/stg-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/stg-brcloud/io.yaml
@@ -18,3 +18,9 @@ definitions:
             hst:homepage: root
             hst:locale: en
             hst:mountpoint: /hst:hee/hst:sites/lks
+            /dental:
+              jcr:primaryType: hst:mount
+              hst:mountpoint: /hst:hee/hst:sites/dental
+            /digital-transformation:
+              jcr:primaryType: hst:mount
+              hst:mountpoint: /hst:hee/hst:sites/digital-transformation

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst-brcloud/io.yaml
@@ -18,3 +18,9 @@ definitions:
             hst:homepage: root
             hst:locale: en
             hst:mountpoint: /hst:hee/hst:sites/lks
+            /dental:
+              jcr:primaryType: hst:mount
+              hst:mountpoint: /hst:hee/hst:sites/dental
+            /digital-transformation:
+              jcr:primaryType: hst:mount
+              hst:mountpoint: /hst:hee/hst:sites/digital-transformation

--- a/repository-data/site/src/main/resources/hcm-content/hst/configurations/dental/workspace/channel/channelinfo.yaml
+++ b/repository-data/site/src/main/resources/hcm-content/hst/configurations/dental/workspace/channel/channelinfo.yaml
@@ -1,0 +1,4 @@
+/hst:hst/hst:configurations/dental/hst:workspace/hst:channel/hst:channelinfo:
+  jcr:primaryType: hst:channelinfo
+  GTMContainerID: GTM-XXXX
+  organizationName: Dental

--- a/repository-data/site/src/main/resources/hcm-content/hst/configurations/digital-transformation/workspace/channel/channelinfo.yaml
+++ b/repository-data/site/src/main/resources/hcm-content/hst/configurations/digital-transformation/workspace/channel/channelinfo.yaml
@@ -1,0 +1,4 @@
+/hst:hst/hst:configurations/digital-transformation/hst:workspace/hst:channel/hst:channelinfo:
+  jcr:primaryType: hst:channelinfo
+  GTMContainerID: GTM-XXXX
+  organizationName: Digital Transformation

--- a/repository-data/site/src/main/resources/hcm-content/hst/sites/dental.yaml
+++ b/repository-data/site/src/main/resources/hcm-content/hst/sites/dental.yaml
@@ -1,0 +1,3 @@
+/hst:hst/hst:sites/dental:
+  jcr:primaryType: hst:site
+  hst:content: /content/documents/dental

--- a/repository-data/site/src/main/resources/hcm-content/hst/sites/digital-transformation.yaml
+++ b/repository-data/site/src/main/resources/hcm-content/hst/sites/digital-transformation.yaml
@@ -1,0 +1,3 @@
+/hst:hst/hst:sites/digital-transformation:
+  jcr:primaryType: hst:site
+  hst:content: /content/documents/digital-transformation


### PR DESCRIPTION
- Dental channel group setup:
  - `dental-author`
  - `dental-editor`
  - `dental-reader`
- Digital Transformation channel group setup:
  - `digital-transformation-author`
  - `digital-transformation-editor`
  - `digital-transformation-reader`
- Dental and Digital Transformation channel security domains setup.
- Dental and Digital Transformation channel documents, gallery (Image) & assets root folder setup.
- Dental and Digital Transformation sample Home page setup [Note that this will not be deployed to env other than dev and so the CMS users of the corresponding channels should create them similar to KLS channel].
- Dental and Digital Transformation HST configuration setup.
- HST host setup for https://dental.hee.nhs.uk and https://digital-transformation.hee.nhs.uk for prod.

Note that the CMS users of Dental and Digital Transformation channels should be advised to update `GTMContainerID` channel parameter/setting. Thanks!