### PR TITLE
HEE-241: Guidance reference updates

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/MiniHub.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/MiniHub.yaml
@@ -72,7 +72,7 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
           /guidancePages:
             jcr:primaryType: frontend:plugin
-            caption: Guidance Pages
+            caption: Standard Content Pages
             field: guidancePages
             hint: ''
             plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/documenttypes.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/documenttypes.yaml
@@ -18,11 +18,11 @@
     /selection:listitem[2]:
       jcr:primaryType: selection:listitem
       selection:key: hee:guidance
-      selection:label: Guidance
+      selection:label: Standard Content Page
     /selection:listitem[3]:
       jcr:primaryType: selection:listitem
       selection:key: hee:landingPage
-      selection:label: LandingPage
+      selection:label: Landing Page
     /selection:listitem[4]:
       jcr:primaryType: selection:listitem
       selection:key: hee:MiniHub

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
@@ -116,7 +116,7 @@ definitions:
               jcr:primaryType: hst:containeritemcomponent
               hst:componentclassname: uk.nhs.hee.web.components.GuidanceComponent
               hst:iconpath: images/catalog-component-icons/simple-content.svg
-              hst:label: Guidance
+              hst:label: Standard Content Page
               hst:template: guidance-main
             /landingpage:
               jcr:primaryType: hst:containeritemcomponent


### PR DESCRIPTION
- MiniHub `Guidance Pages` field caption has beeb updated to `Standard Content Pages`.
- `Guidance` component label has been updated to `Standard Content Page`.
- `Guidance` value-list item [used on ListingPage `Document Types (Applicable for Search Listing Type)` field] has been updated to `Standard Content Page`.