### PR TITLE
HEE-224: Changing (link) text field on link CompoundType as mandatory

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/link.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/link.yaml
@@ -23,6 +23,7 @@ definitions:
             hipposysedit:path: hee:text
             hipposysedit:primary: false
             hipposysedit:type: String
+            hipposysedit:validators: [required]
           /url:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/action-link.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/action-link.ftl
@@ -11,7 +11,7 @@
             <#assign link = "${actionLink.link.url}">
             <#assign openInNewWindow=true/>
         </#if>
-        <#if actionLink.link.text?has_content && link?has_content>
+        <#if link?has_content>
             <div class="nhsuk-action-link">
                 <a class="nhsuk-action-link__link" href="${link}" ${openInNewWindow?then('target="_blank"', '')}>
                     <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/back-link.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/back-link.ftl
@@ -3,14 +3,12 @@
 <#import "./link.ftl" as hlink>
 
 <#macro backLink link>
-    <#if link.text?has_content>
-        <div class="nhsuk-back-link">
-            <@hlink.link link=link cssClassName="nhsuk-back-link__link">
-                <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-                </svg>
-                ${link.text}
-            </@hlink.link>
-        </div>
-    </#if>
+    <div class="nhsuk-back-link">
+        <@hlink.link link=link cssClassName="nhsuk-back-link__link">
+            <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
+            </svg>
+            ${link.text}
+        </@hlink.link>
+    </div>
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/content-cards.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/content-cards.ftl
@@ -9,7 +9,7 @@
     </#if>
     <ul class="nhsuk-grid-row nhsuk-card-group">
         <#list contentCards.cards as contentCard>
-            <#if contentCard.header.text?has_content && (contentCard.header.document?? || contentCard.header.url?has_content)>
+            <#if contentCard.header.document?? || contentCard.header.url?has_content>
                 <#assign clickableCard=true/>
             <#else>
                 <#assign clickableCard=false/>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/cta-card.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/cta-card.ftl
@@ -11,7 +11,7 @@
             <#assign link = "${ctaCard.ctaCardContentBlock.ctaLink.url}">
             <#assign openInNewWindow=true/>
         </#if>
-        <#if ctaCard.ctaCardContentBlock.ctaLink.text?has_content && link?has_content>
+        <#if link?has_content>
             <div class="nhsuk-grid-column-one-third">
                 <div class="nhsuk-card nhsuk-card--clickable">
                     <div class="nhsuk-card__content">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/quick-links.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/quick-links.ftl
@@ -4,7 +4,6 @@
 
 <#macro quickLinks quickLinks>
     <#if quickLinks?? && quickLinks.links?? && quickLinks.links?size != 0>
-        <#assign hasQuickLinkContent=quickLinks.links?filter(link -> link.text?has_content)?has_content>
         <div class="nhsuk-grid-column-one-third">
             <#if quickLinks.title?has_content || hasQuickLinkContent>
                 <div class="nhsuk-card">
@@ -13,19 +12,18 @@
                             <h3 class="nhsuk-card__heading">${quickLinks.title}</h3>
                         </#if>
 
-                        <#if hasQuickLinkContent>
-                            <ul class="nhsuk-related-links-card__list">
-                                <#list quickLinks.links as quickLink>
-                                    <#if quickLink.text?has_content>
-                                        <li>
-                                            <@hlink.link link=quickLink cssClassName="nhsuk-related-links-card__link">
-                                                ${quickLink.text}
-                                            </@hlink.link>
-                                        </li>
-                                    </#if>
-                                </#list>
-                            </ul>
-                        </#if>
+                        <ul class="nhsuk-related-links-card__list">
+                            <#list quickLinks.links as quickLink>
+                                <#--  The following condition has been added to not to print empty lists when both link document and URL aren't available  -->
+                                <#if quickLink.document?? || quickLink.url?has_content>
+                                    <li>
+                                        <@hlink.link link=quickLink cssClassName="nhsuk-related-links-card__link">
+                                            ${quickLink.text}
+                                        </@hlink.link>
+                                    </li>
+                                </#if>
+                            </#list>
+                        </ul>
                     </div>
                 </div>
             </#if>


### PR DESCRIPTION
For Ref: The link CompoundType is currently being used on the following Document and Compound Types:
- ContentCard
- QuickLinks
- ActionLink
- AfterForm
- ctaCard

The corresponding templates of the above have been updated to remove link `text` value verification. Thanks!