### PR TITLE
HEE-351: Cookies sitemap and component configuration build with option to fallback to KLS Cookies document

### DIFF
--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/cookies.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/cookies.yaml
@@ -1,0 +1,271 @@
+/content/documents/lks/cookies:
+  jcr:primaryType: hippo:handle
+  jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
+  jcr:uuid: 55ca5e1c-cc43-4edd-8fde-f61e4f045ff2
+  hippo:name: Cookies
+  hippo:versionHistory: 61f55634-ef55-45b6-b142-9b20bad5a72f
+  /cookies[1]:
+    jcr:primaryType: hee:guidance
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: a388b00d-4a83-4dd8-9b2e-adb545f5d267
+    hee:summary: When we provide online services, we want to make them easy, useful
+      and reliable. To make our services work better, we sometimes put small amounts
+      of information on your computer, tablet or phone.
+    hee:title: Cookies on the HEE website
+    hippo:availability: []
+    hippostd:retainable: false
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2021-09-08T14:04:38.533+01:00
+    hippostdpubwf:lastModificationDate: 2021-09-21T13:12:36.781+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 9cd6f136-4634-4959-b4a0-90e3b1595cdb
+    hippotranslation:locale: en
+    /hee:relatedContent:
+      jcr:primaryType: hee:contentCards
+      hee:header: ''
+      /hee:cards:
+        jcr:primaryType: hippo:mirror
+        hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+    /hee:pageLastNextReview:
+      jcr:primaryType: hee:pageLastNextReview
+      hee:lastReviewed: 2021-09-21T00:00:00+01:00
+      hee:nextReviewed: 2021-12-21T00:00:00Z
+    /hee:contentBlocks:
+      jcr:primaryType: hippostd:html
+      hippostd:content: |-
+        <p>This includes small files known as cookies. We cannot use them to identify you personally.&nbsp;</p>
+
+        <p>We use cookies to:</p>
+
+        <ul>
+         <li>recognise your device so you do not&nbsp;have to give the same information several times during one task</li>
+         <li>make sure you do not have to keep logging in when you've already done so</li>
+         <li>measure how many people are using our services</li>
+         <li>analyse anonymised data to understand how people use our services</li>
+        </ul>
+
+        <p>We use this information to improve services for you.</p>
+
+        <h2>Current cookies</h2>
+
+        <p>We use a series of cookies to measure our website's speed and how people are using it. We also use them to make sure any preferences you've chosen are the same when you return to our website.</p>
+
+        <table border="1" cellpadding="1" cellspacing="1">
+         <tbody>
+          <tr>
+           <td>Name</td>
+           <td>Purpose</td>
+           <td>Duration</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+         </tbody>
+        </table>
+
+        <p>Full details about Google Analytics cookies are published on the <a href="http://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage" target="_blank">Google website (opens in new window)</a>. Google also publishes a <a href="http://chrome.google.com/webstore/detail/google-analytics-opt-out/fllaojicojecljbmefodhfapmkghcbnh?hl=en-GB" target="_blank">browser add-on (opens in new window)</a> which lets you stop information about your website visit being sent to Google Analytics.</p>
+  /cookies[2]:
+    jcr:primaryType: hee:guidance
+    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+    jcr:uuid: eaf41d9e-39b0-445a-927c-117759e603a9
+    hee:summary: When we provide online services, we want to make them easy, useful
+      and reliable. To make our services work better, we sometimes put small amounts
+      of information on your computer, tablet or phone.
+    hee:title: Cookies on the HEE website
+    hippo:availability: [preview]
+    hippostd:retainable: false
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2021-09-08T14:04:38.533+01:00
+    hippostdpubwf:lastModificationDate: 2021-09-21T13:12:20.475+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 9cd6f136-4634-4959-b4a0-90e3b1595cdb
+    hippotranslation:locale: en
+    /hee:relatedContent:
+      jcr:primaryType: hee:contentCards
+      hee:header: ''
+      /hee:cards:
+        jcr:primaryType: hippo:mirror
+        hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+    /hee:pageLastNextReview:
+      jcr:primaryType: hee:pageLastNextReview
+      hee:lastReviewed: 2021-09-21T00:00:00+01:00
+      hee:nextReviewed: 2021-12-21T00:00:00Z
+    /hee:contentBlocks:
+      jcr:primaryType: hippostd:html
+      hippostd:content: |-
+        <p>This includes small files known as cookies. We cannot use them to identify you personally.&nbsp;</p>
+
+        <p>We use cookies to:</p>
+
+        <ul>
+         <li>recognise your device so you do not&nbsp;have to give the same information several times during one task</li>
+         <li>make sure you do not have to keep logging in when you've already done so</li>
+         <li>measure how many people are using our services</li>
+         <li>analyse anonymised data to understand how people use our services</li>
+        </ul>
+
+        <p>We use this information to improve services for you.</p>
+
+        <h2>Current cookies</h2>
+
+        <p>We use a series of cookies to measure our website's speed and how people are using it. We also use them to make sure any preferences you've chosen are the same when you return to our website.</p>
+
+        <table border="1" cellpadding="1" cellspacing="1">
+         <tbody>
+          <tr>
+           <td>Name</td>
+           <td>Purpose</td>
+           <td>Duration</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+         </tbody>
+        </table>
+
+        <p>Full details about Google Analytics cookies are published on the <a href="http://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage" target="_blank">Google website (opens in new window)</a>. Google also publishes a <a href="http://chrome.google.com/webstore/detail/google-analytics-opt-out/fllaojicojecljbmefodhfapmkghcbnh?hl=en-GB" target="_blank">browser add-on (opens in new window)</a> which lets you stop information about your website visit being sent to Google Analytics.</p>
+  /cookies[3]:
+    jcr:primaryType: hee:guidance
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: 3855c93e-531f-4000-9fba-2bb160d2084e
+    hee:summary: When we provide online services, we want to make them easy, useful
+      and reliable. To make our services work better, we sometimes put small amounts
+      of information on your computer, tablet or phone.
+    hee:title: Cookies on the HEE website
+    hippo:availability: [live]
+    hippostd:retainable: false
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2021-09-08T14:04:38.533+01:00
+    hippostdpubwf:lastModificationDate: 2021-09-21T13:12:20.475+01:00
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2021-09-22T16:24:47.093+01:00
+    hippotranslation:id: 9cd6f136-4634-4959-b4a0-90e3b1595cdb
+    hippotranslation:locale: en
+    /hee:relatedContent:
+      jcr:primaryType: hee:contentCards
+      hee:header: ''
+      /hee:cards:
+        jcr:primaryType: hippo:mirror
+        hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+    /hee:pageLastNextReview:
+      jcr:primaryType: hee:pageLastNextReview
+      hee:lastReviewed: 2021-09-21T00:00:00+01:00
+      hee:nextReviewed: 2021-12-21T00:00:00Z
+    /hee:contentBlocks:
+      jcr:primaryType: hippostd:html
+      hippostd:content: |-
+        <p>This includes small files known as cookies. We cannot use them to identify you personally.&nbsp;</p>
+
+        <p>We use cookies to:</p>
+
+        <ul>
+         <li>recognise your device so you do not&nbsp;have to give the same information several times during one task</li>
+         <li>make sure you do not have to keep logging in when you've already done so</li>
+         <li>measure how many people are using our services</li>
+         <li>analyse anonymised data to understand how people use our services</li>
+        </ul>
+
+        <p>We use this information to improve services for you.</p>
+
+        <h2>Current cookies</h2>
+
+        <p>We use a series of cookies to measure our website's speed and how people are using it. We also use them to make sure any preferences you've chosen are the same when you return to our website.</p>
+
+        <table border="1" cellpadding="1" cellspacing="1">
+         <tbody>
+          <tr>
+           <td>Name</td>
+           <td>Purpose</td>
+           <td>Duration</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+          <tr>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+           <td>&nbsp;</td>
+          </tr>
+         </tbody>
+        </table>
+
+        <p>Full details about Google Analytics cookies are published on the <a href="http://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage" target="_blank">Google website (opens in new window)</a>. Google also publishes a <a href="http://chrome.google.com/webstore/detail/google-analytics-opt-out/fllaojicojecljbmefodhfapmkghcbnh?hl=en-GB" target="_blank">browser add-on (opens in new window)</a> which lets you stop information about your website visit being sent to Google Analytics.</p>

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
@@ -30,6 +30,11 @@ definitions:
               hst:componentconfigurationid: hst:pages/searchresults
               hst:pagetitle: Search
               hst:relativecontentpath: listing-pages/search-results
+          /cookies:
+            jcr:primaryType: hst:sitemapitem
+            hst:componentconfigurationid: hst:pages/cookies
+            hst:pagetitle: Cookies
+            hst:refId: cookies
         /hst:abstractpages:
           jcr:primaryType: hst:pages
         /hst:pages:

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/cookies.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/cookies.yaml
@@ -1,0 +1,11 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/common/hst:pages/cookies:
+      jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/base
+      /main:
+        jcr:primaryType: hst:component
+        hst:componentclassname: uk.nhs.hee.web.components.CookiesPageComponent
+        hst:template: guidance-main
+        hst:parameternames: [document, fallbackSiteContentBasePath]
+        hst:parametervalues: [cookies, /content/documents/lks]

--- a/site/components/src/main/java/uk/nhs/hee/web/components/CookiesPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/CookiesPageComponent.java
@@ -1,0 +1,64 @@
+package uk.nhs.hee.web.components;
+
+import org.hippoecm.hst.content.beans.ObjectBeanManagerException;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import org.hippoecm.hst.core.parameters.ParametersInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.nhs.hee.web.beans.Guidance;
+import uk.nhs.hee.web.components.info.CookiesPageComponentInfo;
+
+@ParametersInfo(type = CookiesPageComponentInfo.class)
+public class CookiesPageComponent extends GuidanceComponent {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CookiesPageComponent.class);
+
+    @Override
+    public void doBeforeRender(final HstRequest request, final HstResponse response) {
+        super.doBeforeRender(request, response);
+        final Guidance cookieGuidance = request.getModel(REQUEST_ATTR_DOCUMENT);
+
+        if (cookieGuidance != null) {
+            return;
+        }
+
+        LOGGER.debug("No 'Cookies' Guidance/Standard Content Page document exists on the current channel. " +
+                "Checking if one exists on the fallback channel configured via 'fallbackSiteContentBasePath' " +
+                "component parameter.");
+
+        final String fallbackSiteContentBasePath = getComponentParameter("fallbackSiteContentBasePath");
+        LOGGER.debug("Configured 'fallbackSiteContentBasePath' component parameter = {}",
+                fallbackSiteContentBasePath);
+
+        HippoBean fallbackSiteContentBean = null;
+        try {
+            fallbackSiteContentBean = (HippoBean) request.getRequestContext()
+                    .getObjectBeanManager().getObject(fallbackSiteContentBasePath);
+        } catch (final ObjectBeanManagerException e) {
+            LOGGER.info(
+                    "Caught error '{}' while getting HippoBean object for the path '{}'",
+                    e.getMessage(),
+                    fallbackSiteContentBasePath,
+                    e);
+        }
+
+        if (fallbackSiteContentBean == null) {
+            pageNotFound(response);
+            return;
+        }
+
+        final Guidance fallbackCookieGuidance =
+                fallbackSiteContentBean.getBean(getComponentParameter("document"), Guidance.class);
+
+        if (fallbackCookieGuidance == null) {
+            pageNotFound(response);
+            return;
+        }
+
+        LOGGER.debug("'Cookies' Guidance/Standard Content Page document exists on the " +
+                        "fallback channel content base path '{}' configured via 'fallbackSiteContentBasePath'",
+                fallbackSiteContentBasePath);
+        request.setModel(REQUEST_ATTR_DOCUMENT, fallbackCookieGuidance);
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/components/info/CookiesPageComponentInfo.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/info/CookiesPageComponentInfo.java
@@ -1,0 +1,13 @@
+package uk.nhs.hee.web.components.info;
+
+import org.hippoecm.hst.core.parameters.Parameter;
+import org.onehippo.cms7.essentials.components.info.EssentialsDocumentComponentInfo;
+
+public interface CookiesPageComponentInfo extends EssentialsDocumentComponentInfo {
+    @Parameter(
+            name = "fallbackSiteContentBasePath",
+            displayName = "Fallback site content base path",
+            defaultValue = "/content/documents/lks"
+    )
+    String getFallbackSiteContentBasePath();
+}

--- a/site/components/src/test/java/uk/nhs/hee/web/components/BreadcrumbComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/components/BreadcrumbComponentTest.java
@@ -1,4 +1,4 @@
-package uk.nhs.hee.web.uk.nhs.hee.web.components;
+package uk.nhs.hee.web.components;
 
 import org.hippoecm.hst.configuration.hosting.Mount;
 import org.hippoecm.hst.configuration.site.HstSite;
@@ -23,13 +23,11 @@ import org.onehippo.cms7.essentials.components.ext.DoBeforeRenderExtension;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import uk.nhs.hee.web.components.BreadcrumbComponent;
 import uk.nhs.hee.web.components.beans.BreadcrumbLinkTest;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 

--- a/site/components/src/test/java/uk/nhs/hee/web/components/CookiesPageComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/components/CookiesPageComponentTest.java
@@ -1,0 +1,148 @@
+package uk.nhs.hee.web.components;
+
+import org.hippoecm.hst.container.RequestContextProvider;
+import org.hippoecm.hst.content.beans.manager.ObjectBeanManager;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import org.hippoecm.hst.core.container.ComponentManager;
+import org.hippoecm.hst.core.request.HstRequestContext;
+import org.hippoecm.hst.mock.core.component.MockHstRequest;
+import org.hippoecm.hst.site.HstServices;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.onehippo.cms7.essentials.components.ext.DoBeforeRenderExtension;
+import org.onehippo.cms7.essentials.components.info.EssentialsDocumentComponentInfo;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import uk.nhs.hee.web.beans.Guidance;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*", "javax.script.*"})
+@PrepareForTest({HstServices.class, RequestContextProvider.class})
+public class CookiesPageComponentTest {
+
+    private static final String COMPONENT_PARAMETER_NAME_DOCUMENT = "document";
+    private static final String COMPONENT_PARAMETER_NAME_FALLBACK_SITE_CONTENT_BASE_PATH = "fallbackSiteContentBasePath";
+
+    private static final String COMPONENT_PARAMETER_VALUE_DOCUMENT = "cookies";
+    private static final String COMPONENT_PARAMETER_VALUE_FALLBACK_SITE_CONTENT_BASE_PATH = "/content/documents/lks";
+
+    private static final String MODEL_NAME_DOCUMENT = "document";
+
+    // Mocks
+    private final HstRequest mockHstRequest = spy(new MockHstRequest());
+    @Mock
+    private HstResponse mockHstResponse;
+    @Mock
+    private HstRequestContext mockHstRequestContext;
+    @Mock
+    private ComponentManager mockComponentManager;
+    @Mock
+    private ObjectBeanManager mockObjectBeanManager;
+    @Mock
+    private EssentialsDocumentComponentInfo mockEssentialsDocumentComponentInfo;
+    @Mock
+    private HippoBean mockSiteContentBaseBean;
+    @Mock
+    private Guidance mockChannelCookieGuidance;
+    @Mock
+    private HippoBean mockFallbackSiteContentBaseBean;
+    @Mock
+    private Guidance mockFallbackChannelCookieGuidance;
+
+    private CookiesPageComponent systemUnderTest;
+
+    @Before
+    public void setUp() {
+        // Mocks & stubs
+        // Do nothing when org.onehippo.cms7.essentials.components.CommonComponent#doBeforeRender
+        // has been called from CookiesPageComponent via super.doBeforeRender(request, response).
+        mockStatic(HstServices.class, RequestContextProvider.class);
+        when(HstServices.getComponentManager()).thenReturn(mockComponentManager);
+        when(mockComponentManager.getComponent(DoBeforeRenderExtension.class.getName())).thenReturn(null);
+        when(RequestContextProvider.get()).thenReturn(mockHstRequestContext);
+        when(mockHstRequestContext.isChannelManagerPreviewRequest()).thenReturn(false);
+
+        // Stubbing for org.onehippo.cms7.essentials.components.EssentialsDocumentComponent.doBeforeRender call
+        when(mockEssentialsDocumentComponentInfo.getDocument()).thenReturn(COMPONENT_PARAMETER_VALUE_DOCUMENT);
+        when(mockHstRequest.getRequestContext()).thenReturn(mockHstRequestContext);
+        when(mockHstRequestContext.getSiteContentBaseBean()).thenReturn(mockSiteContentBaseBean);
+        when(mockHstRequestContext.getObjectBeanManager()).thenReturn(mockObjectBeanManager);
+
+        systemUnderTest = spy(new CookiesPageComponent() {
+            @Override
+            protected <T> T getComponentParametersInfo(final HstRequest request) {
+                return (T) mockEssentialsDocumentComponentInfo;
+            }
+
+            @Override
+            public String getComponentParameter(final String name) {
+                if (COMPONENT_PARAMETER_NAME_FALLBACK_SITE_CONTENT_BASE_PATH.equals(name)) {
+                    return COMPONENT_PARAMETER_VALUE_FALLBACK_SITE_CONTENT_BASE_PATH;
+                }
+
+                if (COMPONENT_PARAMETER_NAME_DOCUMENT.equals(name)) {
+                    return COMPONENT_PARAMETER_VALUE_DOCUMENT;
+                }
+
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void doBeforeRender_WithChannelCookiesDocExists_AddsChannelCookieGuidanceToModel() {
+        // Mocks & stubs
+        when(mockSiteContentBaseBean.getBean(COMPONENT_PARAMETER_VALUE_DOCUMENT)).thenReturn(mockChannelCookieGuidance);
+
+        // Execute the method to be tested
+        systemUnderTest.doBeforeRender(mockHstRequest, mockHstResponse);
+
+        // Verify
+        assertThat((Guidance) mockHstRequest.getModel(MODEL_NAME_DOCUMENT)).isEqualTo(mockChannelCookieGuidance);
+        verify(systemUnderTest, never()).pageNotFound(mockHstResponse);
+    }
+
+    @Test
+    public void doBeforeRender_WithChannelCookiesDocNotExistsButOneExistsOnFallbackChannel_AddsFallbackChannelCookieGuidanceToModel()
+            throws Exception {
+        // Mocks & stubs
+        when(mockObjectBeanManager.getObject(COMPONENT_PARAMETER_VALUE_FALLBACK_SITE_CONTENT_BASE_PATH))
+                .thenReturn(mockFallbackSiteContentBaseBean);
+        when(mockFallbackSiteContentBaseBean.getBean(COMPONENT_PARAMETER_VALUE_DOCUMENT, Guidance.class))
+                .thenReturn(mockFallbackChannelCookieGuidance);
+
+        // fallbackSiteContentBean.getBean(getComponentParameter("document"), Guidance.class)
+        // Execute the method to be tested
+        systemUnderTest.doBeforeRender(mockHstRequest, mockHstResponse);
+
+        // Verify
+        assertThat((Guidance) mockHstRequest.getModel(MODEL_NAME_DOCUMENT))
+                .isEqualTo(mockFallbackChannelCookieGuidance);
+        verify(systemUnderTest, never()).pageNotFound(mockHstResponse);
+    }
+
+    @Test
+    public void doBeforeRender_WithChannelCookiesDocNotExistsAndOneNotExistsOnFallbackChannel_AddsNoCookieGuidanceToModel()
+            throws Exception {
+        // Mocks & stubs
+        when(mockObjectBeanManager.getObject(COMPONENT_PARAMETER_VALUE_FALLBACK_SITE_CONTENT_BASE_PATH))
+                .thenReturn(mockFallbackSiteContentBaseBean);
+
+        // fallbackSiteContentBean.getBean(getComponentParameter("document"), Guidance.class)
+        // Execute the method to be tested
+        systemUnderTest.doBeforeRender(mockHstRequest, mockHstResponse);
+
+        // Verify
+        assertThat((Guidance) mockHstRequest.getModel(MODEL_NAME_DOCUMENT)).isNull();
+        verify(systemUnderTest, times(1)).pageNotFound(mockHstResponse);
+    }
+}

--- a/site/components/src/test/java/uk/nhs/hee/web/repository/HEEFieldTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/repository/HEEFieldTest.java
@@ -1,7 +1,6 @@
-package uk.nhs.hee.web.uk.nhs.hee.web.repository;
+package uk.nhs.hee.web.repository;
 
 import org.junit.Test;
-import uk.nhs.hee.web.repository.HEEField;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/site/components/src/test/java/uk/nhs/hee/web/repository/ValueListIdentifierTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/repository/ValueListIdentifierTest.java
@@ -1,7 +1,6 @@
-package uk.nhs.hee.web.uk.nhs.hee.web.repository;
+package uk.nhs.hee.web.repository;
 
 import org.junit.Test;
-import uk.nhs.hee.web.repository.ValueListIdentifier;
 
 import static org.assertj.core.api.Assertions.*;
 


### PR DESCRIPTION
**Highlights of the implementation:**
- A SiteMapItem `/hst:hee/hst:configurations/common/hst:sitemap/cookies` has been added to serve Cookies page for all channels under `/cookies` path.
- A component configuration `/hst:hee/hst:configurations/common/hst:pages/cookies` has been added to render Cookies page based on the `Cookies` Guidance document added under the channel root (e.g. `/content/documents/lks/cookies`). The component class `uk.nhs.hee.web.components.CookiesPageComponent` has been configured to fall back to KLS channel Cookies document (`/content/documents/lks/cookies`) in case if one isn't available on the current channel (provided the current channel isn't KLS channel). Otherwise, it renders a 404.

Note that additional URLRewriter rules needs to be added to forward `/about/cookies` requests to `/cookies` in case if we need to support `/about/cookies` page path like the one in https://www.hee.nhs.uk.

It is responsibility of the Editor/Design Team (Will) to add `Cookies` Guidance document on the channels based on the Cookie details described in the HEE-92 ticket comment. Thank you!