### PR TITLE
HEE-294: Inclusion of 'robots' response header with 'noindex, nofollow' for prod dental domain mount (/hst:hee/hst:hosts/prd-brcloud/uk/nhs/hee/dental/hst:root)

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
@@ -30,6 +30,7 @@ definitions:
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/dental
+              hst:responseheaders: ['robots: noindex, nofollow']
           /digital-transformation:
             .meta:residual-child-node-category: content
             jcr:primaryType: hst:virtualhost


### PR DESCRIPTION
So that it wouldn’t both be indexed or its links are followed.

Note that this has already been added to prod as it’s a trivial change and needs to be implemented on prod (for dental channel) quickly.