### PR TITLE
Amendment to display CompoundType names for ContentBlock based fields of blogpost and homepage

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/HomePage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/HomePage.yaml
@@ -78,3 +78,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              showCompoundNames: 'true'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogPage.yaml
@@ -207,6 +207,7 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              showCompoundNames: 'true'
           /pageLastNextReview:
             jcr:primaryType: frontend:plugin
             caption: Page review dates
@@ -235,3 +236,4 @@ definitions:
             wicket.id: ${cluster.id}.right.item
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              showCompoundNames: 'true'


### PR DESCRIPTION
In order to be inline with `guidance` DocumentType ContentBlock convention.