### PR TITLE
HEE-233: Switching off the ability to add comments to blog posts

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/default/catalog.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/default/catalog.yaml
@@ -5,14 +5,17 @@ definitions:
     /hst:hst/hst:configurations/hst:default/hst:catalog/eforms-catalog/form:
       hst:parameternames: [behaviors]
       hst:parametervalues: [com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior]
-    /hst:hst/hst:configurations/hst:default/hst:catalog/eforms-catalog/blog-comment-form:
-      jcr:primaryType: hst:containeritemcomponent
-      hst:componentclassname: com.onehippo.cms7.eforms.hst.components.AutoDetectFormComponent
-      hst:iconpath: resources/addon/eforms/images/icons/form.svg
-      hst:label: Blog Comments Form
-      hst:parameternames: [behaviors]
-      hst:parametervalues: ['com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior,
-          uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior']
-      hst:resourcetemplate: eforms.validation.default
-      hst:template: eforms.default
-      hst:xtype: HST.Item
+    /hst:hst/hst:configurations/hst:default/hst:catalog/eforms-blog-catalog:
+      jcr:primaryType: hst:containeritempackage
+      hst:hiddeninchannelmanager: true
+      /blog-comment-form:
+        jcr:primaryType: hst:containeritemcomponent
+        hst:componentclassname: com.onehippo.cms7.eforms.hst.components.AutoDetectFormComponent
+        hst:iconpath: resources/addon/eforms/images/icons/form.svg
+        hst:label: Blog Comments Form
+        hst:parameternames: [behaviors]
+        hst:parametervalues: ['com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior,
+            uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior']
+        hst:resourcetemplate: eforms.validation.default
+        hst:template: eforms.default
+        hst:xtype: HST.Item

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/blogpage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/blogpage-main.ftl
@@ -4,10 +4,12 @@
     <main id="maincontent" role="main" class="nhsuk-main-wrapper">
         <@hst.include ref="blog"/>
 
-        <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
+        <#--  HEE-233: Temporarily switching off the ability to add comment(s) to blog posts
+              while the moderation functionality is being developed  -->
+        <#--  <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
             <div class="nhsuk-grid-column-two-thirds">
                 <@hst.include ref="comment"/>
             </div>
-        </div>
+        </div>  -->
     </main>
 </div>


### PR DESCRIPTION
Note that existing comments on the blog posts will still be displayed. Hope this is OK ?

Since we have commented out `comment` component:
```
<@hst.include ref="comment"/>
```
warning messages similar to the following would be logged:
```
[INFO] [talledLocalContainer] 03.11.2021 12:34:09 WARN  http-nio-8080-exec-3 [AggregationValve.logPossibleWaste:599] POSSIBLE WASTE DETECTED in request 'Request{ method='GET', scheme='http', host='localhost:8080', requestURI='/site/expert-searching', queryString='null'}' : Component '/hst:hee/hst:configurations/lks/hst:workspace/hst:pages/expert-searching-blog-page/main/comment' gets rendered but never adds anything to the response. Its renderer 'classpath:vbox.ftl' is never flushed to a parent component. This might be waste you are not aware of. If it is on purpose, for example because the component does only some processing that does not involve direct response contribution, you can mark the component with 'hst:suppresswastemessage = true'.
```
But, this can be ignored as this PR is essentially a temporary measure. Thanks!