### PR TITLE
NWPS-765: Delivery-tier authentication setup for dental channel

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/userroles/hee.site.viewer.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/userroles/hee.site.viewer.yaml
@@ -1,0 +1,6 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:userroles/hee.site.viewer:
+      jcr:primaryType: hipposys:userrole
+      hipposys:description: Allows CMS users to view delivery-tier authentication
+        enabled channel pages

--- a/repository-data/application/src/main/resources/hcm-config/configuration/userroles/xm.cms.user.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/userroles/xm.cms.user.yaml
@@ -1,0 +1,4 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:userroles/xm.cms.user:
+      hipposys:userroles: [xm.frontend-config.reader, hee.site.viewer]

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts.yaml
@@ -21,6 +21,9 @@ definitions:
             .meta:residual-child-node-category: content
             jcr:primaryType: hst:mount
             hst:mountpoint: /hst:hee/hst:sites/dental
+            hst:responseheaders: ['robots: noindex, nofollow']
+            hst:roles: [site.viewer]
+            hst:authenticated: true
           /medical:
             .meta:residual-child-node-category: content
             jcr:primaryType: hst:mount

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev-brcloud/io.yaml
@@ -21,6 +21,9 @@ definitions:
             /dental:
               jcr:primaryType: hst:mount
               hst:mountpoint: /hst:hee/hst:sites/dental
+              hst:responseheaders: ['robots: noindex, nofollow']
+              hst:roles: [site.viewer]
+              hst:authenticated: true
             /digital-transformation:
               jcr:primaryType: hst:mount
               hst:mountpoint: /hst:hee/hst:sites/digital-transformation

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/io.yaml
@@ -21,6 +21,9 @@ definitions:
             /dental:
               jcr:primaryType: hst:mount
               hst:mountpoint: /hst:hee/hst:sites/dental
+              hst:responseheaders: ['robots: noindex, nofollow']
+              hst:roles: [site.viewer]
+              hst:authenticated: true
             /digital-transformation:
               jcr:primaryType: hst:mount
               hst:mountpoint: /hst:hee/hst:sites/digital-transformation

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
@@ -31,6 +31,8 @@ definitions:
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/dental
               hst:responseheaders: ['robots: noindex, nofollow']
+              hst:roles: [site.viewer]
+              hst:authenticated: true
           /digital-transformation:
             .meta:residual-child-node-category: content
             jcr:primaryType: hst:virtualhost

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/stg-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/stg-brcloud/io.yaml
@@ -21,6 +21,9 @@ definitions:
             /dental:
               jcr:primaryType: hst:mount
               hst:mountpoint: /hst:hee/hst:sites/dental
+              hst:responseheaders: ['robots: noindex, nofollow']
+              hst:roles: [site.viewer]
+              hst:authenticated: true
             /digital-transformation:
               jcr:primaryType: hst:mount
               hst:mountpoint: /hst:hee/hst:sites/digital-transformation

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst-brcloud/io.yaml
@@ -21,6 +21,9 @@ definitions:
             /dental:
               jcr:primaryType: hst:mount
               hst:mountpoint: /hst:hee/hst:sites/dental
+              hst:responseheaders: ['robots: noindex, nofollow']
+              hst:roles: [site.viewer]
+              hst:authenticated: true
             /digital-transformation:
               jcr:primaryType: hst:mount
               hst:mountpoint: /hst:hee/hst:sites/digital-transformation

--- a/site/webapp/src/main/webapp/WEB-INF/hst-config.properties
+++ b/site/webapp/src/main/webapp/WEB-INF/hst-config.properties
@@ -10,3 +10,7 @@ parameter.namespace.ignored=true
 
 # A global content rewriter for rich text fields to rewrite Mini-hub Guidance links (in case if they ends up with 'pagenotfound' by OOTB contentrewriter [org.hippoecm.hst.content.rewriter.impl.SimpleContentRewriter])
 default.hst.contentrewriter.class=uk.nhs.hee.web.content.rewriter.impl.MiniHubGuidanceLinkRewriter
+
+# Delivery-tier RepositoryAuthenticationProvider based authentication
+# Include only HEE userroles (prefixed with hee.)
+security.authentication.included.userrole.prefix = hee.


### PR DESCRIPTION
- Added `hee.site.viewer` userrole to use it for delivery-tier authentication.
- Updated `xm.cms.user` userrole to implicitly include `hee.site.viewer` userrole for all CMS users.
- Enabled authentication for dental channel for all environment virtual hosts.
- Configured delivery-tier `RepositoryAuthenticationProvider` to filter out roles prefixed with `hee.` for authentication (`site/webapp/src/main/webapp/WEB-INF/hst-config.properties`):
```
  security.authentication.included.userrole.prefix = hee.
```

Note that the `login` sitemap protocol needs to be changed to `http` for local development: 
```
/hst:hee/hst:configurations/hst:default/hst:sitemap/login/@hst:scheme=http
```