### PR TITLE
NWPS-416: Clickjacking vulnerability fix

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts.yaml
@@ -7,6 +7,8 @@ definitions:
       /localhost:
         .meta:residual-child-node-category: content
         jcr:primaryType: hst:virtualhost
+        hst:responseheaders: ['Content-Security-Policy: frame-ancestors ''self''',
+          'X-Frame-Options: SAMEORIGIN']
         /hst:root:
           .meta:residual-child-node-category: content
           jcr:primaryType: hst:mount

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev-brcloud/io.yaml
@@ -6,6 +6,8 @@ definitions:
       hst:scheme: https
       hst:showcontextpath: true
       hst:showport: false
+      hst:responseheaders: ['Content-Security-Policy: frame-ancestors ''self''',
+          'X-Frame-Options: SAMEORIGIN']
       /onehippo:
         .meta:residual-child-node-category: content
         jcr:primaryType: hst:virtualhost

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/io.yaml
@@ -6,6 +6,8 @@ definitions:
       hst:scheme: https
       hst:showcontextpath: true
       hst:showport: false
+      hst:responseheaders: ['Content-Security-Policy: frame-ancestors ''self''',
+          'X-Frame-Options: SAMEORIGIN']
       /onehippo:
         .meta:residual-child-node-category: content
         jcr:primaryType: hst:virtualhost

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
@@ -6,6 +6,8 @@ definitions:
       hst:scheme: https
       hst:showcontextpath: false
       hst:showport: false
+      hst:responseheaders: ['Content-Security-Policy: frame-ancestors ''self''',
+          'X-Frame-Options: SAMEORIGIN']
       /nhs:
         .meta:residual-child-node-category: content
         jcr:primaryType: hst:virtualhost

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/stg-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/stg-brcloud/io.yaml
@@ -6,6 +6,8 @@ definitions:
       hst:scheme: https
       hst:showcontextpath: true
       hst:showport: false
+      hst:responseheaders: ['Content-Security-Policy: frame-ancestors ''self''',
+          'X-Frame-Options: SAMEORIGIN']
       /onehippo:
         .meta:residual-child-node-category: content
         jcr:primaryType: hst:virtualhost

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst-brcloud/io.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst-brcloud/io.yaml
@@ -6,6 +6,8 @@ definitions:
       hst:scheme: https
       hst:showcontextpath: true
       hst:showport: false
+      hst:responseheaders: ['Content-Security-Policy: frame-ancestors ''self''',
+          'X-Frame-Options: SAMEORIGIN']
       /onehippo:
         .meta:residual-child-node-category: content
         jcr:primaryType: hst:virtualhost


### PR DESCRIPTION
Have set up both `X-Frame-Options: SAMEORIGIN` as well as `Content-Security-Policy: frame-ancestors 'self'` response headers on all HST virtual hosts to fix clickjacking vulnerability.