### PR TITLE
NWPS-416: Clickjacking vulnerability fix response headers for prod dental domain

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brcloud/uk.yaml
@@ -32,7 +32,8 @@ definitions:
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/dental
-              hst:responseheaders: ['robots: noindex, nofollow']
+              hst:responseheaders: ['robots: noindex, nofollow', 'Content-Security-Policy:
+                  frame-ancestors ''self''', 'X-Frame-Options: SAMEORIGIN']
               hst:roles: [site.viewer]
               hst:authenticated: true
           /digital-transformation:


### PR DESCRIPTION
Including Clickjacking vulnerability fix response headers (`Content-Security-Policy: frame-ancestors 'self'` & `X-Frame-Options: SAMEORIGIN`) explicitly on prod dental domain (`dental.hee.nhs.uk`) mount [as inherited response headers from `/hst:hee/hst:hosts/prd-brcloud/uk` are lost during `hst:responseheaders` property override at the mount level].