### PR TITLE
NWPS-233: Blog moderation implementation

### DIFF
--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -103,7 +103,7 @@ jobs:
           distPath: ${{ steps.dist.outputs.distPath }}
 
       - name: Deploy distribution to 'production' env
-        uses: Manifesto-Digital/deploy-distribution-to-BR-Cloud-action@v1.0
+        uses: Manifesto-Digital/deploy-distribution-to-BR-Cloud-action@v1.1
         id: deploy
         with:
           brcStack: ${{ env.BRC_STACK_NAME }}
@@ -111,3 +111,4 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
+          configFilesAsSystemProperties: 'hee-smtp.properties'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -100,7 +100,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distPath: ${{ steps.dist.outputs.distPath }}
       - name: Deploy distribution to 'development' env
-        uses: Manifesto-Digital/deploy-distribution-to-BR-Cloud-action@v1.0
+        uses: Manifesto-Digital/deploy-distribution-to-BR-Cloud-action@v1.1
         id: deploy
         with:
           brcStack: ${{ env.BRC_STACK_NAME }}
@@ -108,6 +108,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
+          configFilesAsSystemProperties: 'hee-smtp.properties'
 
   deploy-to-test:
     name: Deploy to Test Env. [on brCloud]
@@ -168,7 +169,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distPath: ${{ steps.dist.outputs.distPath }}
       - name: Deploy distribution to 'test' env
-        uses: Manifesto-Digital/deploy-distribution-to-BR-Cloud-action@v1.0
+        uses: Manifesto-Digital/deploy-distribution-to-BR-Cloud-action@v1.1
         id: deploy
         with:
           brcStack: ${{ env.BRC_STACK_NAME }}
@@ -176,6 +177,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
+          configFilesAsSystemProperties: 'hee-smtp.properties'
 
   deploy-to-staging:
     name: Deploy to Staging Env. [on brCloud]
@@ -236,7 +238,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distPath: ${{ steps.dist.outputs.distPath }}
       - name: Deploy distribution to 'staging' env
-        uses: Manifesto-Digital/deploy-distribution-to-BR-Cloud-action@v1.0
+        uses: Manifesto-Digital/deploy-distribution-to-BR-Cloud-action@v1.1
         id: deploy
         with:
           brcStack: ${{ env.BRC_STACK_NAME }}
@@ -244,3 +246,4 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
+          configFilesAsSystemProperties: 'hee-smtp.properties'

--- a/conf/context-dev.xml
+++ b/conf/context-dev.xml
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Context>
+    <!-- Disable session persistence across Tomcat restarts -->
+    <Manager pathname="" />
+
+    <!-- Change the default repository storage location -->
+    <!--
+    <Parameter name="repository-directory" value="/data/storage" override="false"/>
+    -->
+
+    <!-- Start the repository as a remote server and bind it on the specified address -->
+    <!--
+    <Parameter name="start-remote-server" value="true" override="false"/>
+    <Parameter name="repository-address" value="rmi://127.0.0.1:1099/hipporepository" override="false"/>
+    -->
+
+    <!-- Enable this to let wicket output a wicketpath attribute for elements,
+         see: https://www.onehippo.org/library/development/create-a-selenium-test-case.html -->
+    <!--
+    <Parameter name="output-wicketpaths" value="true"/>
+    -->
+
+    <!-- 'mail/Session' JavaMail connection factory JNDI resource -->
+    <Resource name="mail/Session"
+              auth="Container"
+              type="javax.mail.Session"
+              mail.transport.protocol="smtp"
+              mail.smtp.host="${mail.smtp.host}"
+              mail.smtp.port="${mail.smtp.port}"
+              mail.smtp.user="${mail.smtp.user}"
+              password="${mail.smtp.password}"
+              mail.smtp.auth="${mail.smtp.auth}"
+              mail.smtp.starttls.enable="${mail.smtp.starttls.enable}"/>
+</Context>

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
               <configuration>
                 <configfiles>
                   <configfile>
-                    <file>${project.basedir}/conf/context.xml</file>
+                    <file>${project.basedir}/conf/context-dev.xml</file>
                     <todir>conf/</todir>
                     <tofile>context.xml</tofile>
                   </configfile>
@@ -443,6 +443,15 @@
                   <!-- enables auto export and web files watch: -->
                   <project.basedir>${project.basedir}</project.basedir>
                   <send.usage.statistics.to.hippo>true</send.usage.statistics.to.hippo>
+
+                  <!-- Example to pass JavaMail connection factory JNDI resource attribute values as system properties -->
+                  <!-- Alternatively these could directly be configured on 'conf/context-dev.xml'  -->
+                  <!-- <mail.smtp.host><<mail.smtp.host>></mail.smtp.host></mail.smtp.host>
+                  <mail.smtp.port><<mail.smtp.port>></mail.smtp.port>
+                  <mail.smtp.user><<mail.smtp.user>></mail.smtp.user>
+                  <mail.smtp.password><<mail.smtp.password>></mail.smtp.password>
+                  <mail.smtp.auth><<mail.smtp.authv</mail.smtp.auth>
+                  <mail.smtp.starttls.enable><<mail.smtp.starttls.enable>></mail.smtp.starttls.enable> -->
                 </systemProperties>
               </container>
             </configuration>

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/AddModerationStatusToBlogPostDocuments.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/AddModerationStatusToBlogPostDocuments.yaml
@@ -1,0 +1,23 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/AddModerationStatusToBlogPostDocuments:
+      jcr:primaryType: hipposys:updaterinfo
+      hipposys:batchsize: 10
+      hipposys:description: Adds moderation status i.e. 'hee:moderated' property to
+        existing comments of the blog post documents (hee:blogPost).
+      hipposys:dryrun: false
+      hipposys:loglevel: DEBUG
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/content/documents//element(hee:comments, hee:blogComment)[not(@hee:moderated
+        != '')]
+      hipposys:script: "package org.hippoecm.frontend.plugins.cms.admin.updater\r\n\
+        \r\n\r\nimport org.onehippo.repository.update.BaseNodeUpdateVisitor\r\n\r\n\
+        import javax.jcr.Node\r\n\r\nclass AddModerationStatusToBlogPostDocuments\
+        \ extends BaseNodeUpdateVisitor {\r\n\r\n    boolean doUpdate(Node node) {\r\
+        \n        log.debug \"Updating node ${node.path}\"\r\n        node.setProperty(\"\
+        hee:moderated\", Boolean.TRUE)\r\n        log.debug \"Successfully added 'hee:moderated=true'\
+        \ property to the blog post comment node '${node.path}'\"\r\n        return\
+        \ true\r\n    }\r\n\r\n    boolean undoUpdate(Node node) {\r\n        throw\
+        \ new UnsupportedOperationException('Updater does not implement undoUpdate\
+        \ method')\r\n    }\r\n\r\n}"
+      hipposys:throttle: 1000

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/UpdateBlogCommentFormContainerComponentsWithBlogPostModerationComponentConfig.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/UpdateBlogCommentFormContainerComponentsWithBlogPostModerationComponentConfig.yaml
@@ -26,7 +26,7 @@ definitions:
         \ // existing form param value\r\n                \"com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior,\
         \ uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior, uk.nhs.hee.web.eforms.hst.behaviors.BlogPostCommentMailFormDataBehavior\"\
         ,\r\n                \"mail/Session\",\r\n                \"true\",\r\n  \
-        \              \"CMS Admin [Dev]\",\r\n                \"cms.admin.dev@hee.nhs.uk\"\
+        \              \"CMS Admin\",\r\n                \"cms.admin@hee.nhs.uk\"\
         ]\r\n        node.setProperty(\"hst:parameternames\", paramNames)\r\n    \
         \    node.setProperty(\"hst:parametervalues\", paramValues)\r\n        log.debug\
         \ \"Successfully updated blog comment form container component '${node.path}'\

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/UpdateBlogCommentFormContainerComponentsWithBlogPostModerationComponentConfig.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/UpdateBlogCommentFormContainerComponentsWithBlogPostModerationComponentConfig.yaml
@@ -1,0 +1,36 @@
+definitions:
+  config:
+    ? /hippo:configuration/hippo:update/hippo:registry/UpdateBlogCommentFormContainerComponentsWithBlogPostModerationComponentConfig
+    : jcr:primaryType: hipposys:updaterinfo
+      hipposys:batchsize: 10
+      hipposys:description: Update blog-comment-form (container) component with blog
+        post moderation component config (e.g. hst:componentclassname, hst:parameternames,
+        etc)
+      hipposys:dryrun: false
+      hipposys:loglevel: DEBUG
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/hst:hee/hst:configurations/element(*, hst:configuration)/hst:workspace/hst:pages//element(blog-comment-form,
+        hst:containeritemcomponent)[jcr:contains(@hst:parametervalues, 'uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior')]
+      hipposys:script: "package org.hippoecm.frontend.plugins.cms.admin.updater\r\n\
+        \r\n\r\nimport org.onehippo.repository.update.BaseNodeUpdateVisitor\r\n\r\n\
+        import javax.jcr.Node\r\n\r\nclass UpdateBlogCommentFormContainerComponentsWithBlogPostModerationComponentConfig\
+        \ extends BaseNodeUpdateVisitor {\r\n\r\n    boolean doUpdate(Node node) {\r\
+        \n        log.debug \"Updating node ${node.path}\"\r\n        node.setProperty(\"\
+        hst:componentclassname\", \"uk.nhs.hee.web.components.eforms.NoAutoDetectFormComponent\"\
+        )\r\n        node.setProperty(\"hst:label\", \"Blog comment form\")\r\n\r\n\
+        \        String[] paramNames = [\r\n                \"form\",\r\n        \
+        \        \"behaviors\",\r\n                \"eforms-mailsession\",\r\n   \
+        \             \"eforms-use-freemarker\",\r\n                \"eforms-from-name\"\
+        ,\r\n                \"eforms-from-email\"]\r\n        String[] paramValues\
+        \ = [\r\n                node.getProperty(\"hst:parametervalues\").getValues()[0].getString(),\
+        \ // existing form param value\r\n                \"com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior,\
+        \ uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior, uk.nhs.hee.web.eforms.hst.behaviors.BlogPostCommentMailFormDataBehavior\"\
+        ,\r\n                \"mail/Session\",\r\n                \"true\",\r\n  \
+        \              \"CMS Admin [Dev]\",\r\n                \"cms.admin.dev@hee.nhs.uk\"\
+        ]\r\n        node.setProperty(\"hst:parameternames\", paramNames)\r\n    \
+        \    node.setProperty(\"hst:parametervalues\", paramValues)\r\n        log.debug\
+        \ \"Successfully updated blog comment form container component '${node.path}'\
+        \ with blog post moderation component config\"\r\n        return true\r\n\
+        \    }\r\n\r\n    boolean undoUpdate(Node node) {\r\n        throw new UnsupportedOperationException('Updater\
+        \ does not implement undoUpdate method')\r\n    }\r\n\r\n}"
+      hipposys:throttle: 1000

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/eforms/form.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/eforms/form.yaml
@@ -12,3 +12,9 @@ definitions:
       plugin.class: com.onehippo.cms7.eforms.cms.extensions.StoreFormDataPlugin
       wicket.id: ${cluster.id}.extensions.item
       wicket.model: ${wicket.model}
+    /hippo:namespaces/eforms/form/editor:templates/_default_/mailform:
+      jcr:primaryType: frontend:plugin
+      mode: ${mode}
+      plugin.class: com.onehippo.cms7.eforms.cms.extensions.MailFormDataPlugin
+      wicket.id: ${cluster.id}.extensions.item
+      wicket.model: ${wicket.model}

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogComment.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogComment.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: 3b442b4b-c555-4cad-8421-2cc58baf23d5
+          jcr:uuid: 3a0bd648-b44f-42e1-bdc7-5ff935b8e76f
           hipposysedit:node: true
           hipposysedit:supertype: ['hippo:compound', 'hippostd:relaxed']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -39,12 +39,21 @@ definitions:
             hipposysedit:path: hee:postedDate
             hipposysedit:primary: false
             hipposysedit:type: Date
+          /moderated:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:moderated
+            hipposysedit:primary: false
+            hipposysedit:type: Boolean
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
           jcr:primaryType: hee:blogComment
           hee:message: ''
           hee:postedDate: 0001-01-01T19:00:00+07:00
+          hee:moderated: false
           /hee:author:
             jcr:primaryType: hee:blogCommentAuthor
             hee:email: ''
@@ -84,6 +93,15 @@ definitions:
             jcr:primaryType: frontend:plugin
             caption: Posted date
             field: postedDate
+            hint: ''
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+          /moderated:
+            jcr:primaryType: frontend:plugin
+            caption: Moderated ?
+            field: moderated
             hint: ''
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field

--- a/repository-data/development/src/main/resources/hcm-actions.yaml
+++ b/repository-data/development/src/main/resources/hcm-actions.yaml
@@ -57,3 +57,6 @@ action-lists:
       /content/documents/lks/guidance-pages: reload
   - 1.0.32:
       /content/documents/lks/home: reload
+  - 1.0.33:
+      /content/documents/lks/blogposts: reload
+      /content/documents/lks/forms/blogcomment: reload

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/blogposts.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/blogposts.yaml
@@ -11,7 +11,7 @@
     jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
     jcr:uuid: 93ffaaf2-ec10-4ebc-a1ca-9bc421108dd1
     hippo:name: ExpertsSearch
-    hippo:versionHistory: 6c0da701-bbf4-4f66-ad4b-81ff43ed0942
+    hippo:versionHistory: bb893153-fff1-4546-9aa3-38bb9e770ff6
     /expertssearch[1]:
       jcr:primaryType: hee:blogPost
       jcr:mixinTypes: ['mix:referenceable']
@@ -27,8 +27,8 @@
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-03-31T13:40:03.121+01:00
-      hippostdpubwf:lastModificationDate: 2021-09-13T15:07:46.736+01:00
-      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:lastModificationDate: 2021-11-22T17:04:57.927Z
+      hippostdpubwf:lastModifiedBy: sitewriter
       hippotranslation:id: 218a718e-20bb-418f-bb6c-cd85561b56d4
       hippotranslation:locale: en
       /hee:pageLastNextReview:
@@ -57,6 +57,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:00:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -68,6 +69,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:16:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -79,6 +81,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:19:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -90,6 +93,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:19:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -99,6 +103,7 @@
       /hee:comments[5]:
         jcr:primaryType: hee:blogComment
         hee:message: Tho
+        hee:moderated: true
         hee:postedDate: 2021-05-07T10:08:00+01:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -108,6 +113,7 @@
       /hee:comments[6]:
         jcr:primaryType: hee:blogComment
         hee:message: Today
+        hee:moderated: true
         hee:postedDate: 2021-05-07T10:15:00+01:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -117,6 +123,7 @@
       /hee:comments[7]:
         jcr:primaryType: hee:blogComment
         hee:message: Testing on Monday
+        hee:moderated: true
         hee:postedDate: 2021-05-10T02:44:00+01:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -203,8 +210,8 @@
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-03-31T13:40:03.121+01:00
-      hippostdpubwf:lastModificationDate: 2021-09-13T15:08:03.016+01:00
-      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:lastModificationDate: 2021-11-22T17:04:58.885Z
+      hippostdpubwf:lastModifiedBy: sitewriter
       hippotranslation:id: 218a718e-20bb-418f-bb6c-cd85561b56d4
       hippotranslation:locale: en
       /hee:pageLastNextReview:
@@ -233,6 +240,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:00:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -244,6 +252,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:16:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -255,6 +264,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:19:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -266,6 +276,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:19:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -275,6 +286,7 @@
       /hee:comments[5]:
         jcr:primaryType: hee:blogComment
         hee:message: Tho
+        hee:moderated: true
         hee:postedDate: 2021-05-07T10:08:00+01:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -284,6 +296,7 @@
       /hee:comments[6]:
         jcr:primaryType: hee:blogComment
         hee:message: Today
+        hee:moderated: true
         hee:postedDate: 2021-05-07T10:15:00+01:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -293,6 +306,7 @@
       /hee:comments[7]:
         jcr:primaryType: hee:blogComment
         hee:message: Testing on Monday
+        hee:moderated: true
         hee:postedDate: 2021-05-10T02:44:00+01:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -379,9 +393,9 @@
       hippostd:state: published
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-03-31T13:40:03.121+01:00
-      hippostdpubwf:lastModificationDate: 2021-09-13T15:08:03.016+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2021-09-13T15:08:05.271+01:00
+      hippostdpubwf:lastModificationDate: 2021-11-22T17:04:58.885Z
+      hippostdpubwf:lastModifiedBy: sitewriter
+      hippostdpubwf:publicationDate: 2021-11-22T17:04:59.512Z
       hippotranslation:id: 218a718e-20bb-418f-bb6c-cd85561b56d4
       hippotranslation:locale: en
       /hee:pageLastNextReview:
@@ -410,6 +424,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:00:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -421,6 +436,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:16:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -432,6 +448,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:19:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -443,6 +460,7 @@
         hee:message: 'Comment text goes here: Lorem ipsum dolor sit amet, consectetur
           adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit
           amet lacus accumsan et viverra justo commodo.'
+        hee:moderated: true
         hee:postedDate: 2021-05-04T09:19:00+07:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -452,6 +470,7 @@
       /hee:comments[5]:
         jcr:primaryType: hee:blogComment
         hee:message: Tho
+        hee:moderated: true
         hee:postedDate: 2021-05-07T10:08:00+01:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -461,6 +480,7 @@
       /hee:comments[6]:
         jcr:primaryType: hee:blogComment
         hee:message: Today
+        hee:moderated: true
         hee:postedDate: 2021-05-07T10:15:00+01:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor
@@ -470,6 +490,7 @@
       /hee:comments[7]:
         jcr:primaryType: hee:blogComment
         hee:message: Testing on Monday
+        hee:moderated: true
         hee:postedDate: 2021-05-10T02:44:00+01:00
         /hee:author:
           jcr:primaryType: hee:blogCommentAuthor

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/forms.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/forms.yaml
@@ -311,7 +311,7 @@
     jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
     jcr:uuid: 9dd41d06-83d1-41c5-9ae7-9f2884ea778f
     hippo:name: BlogComment
-    hippo:versionHistory: 533b7243-06fc-48e0-af74-5ddbc8590a75
+    hippo:versionHistory: fcd3449d-5025-4fc5-b2e3-63ccb095a60e
     /blogcomment[1]:
       jcr:primaryType: eforms:form
       jcr:mixinTypes: ['hippotranslation:translated', 'mix:referenceable']
@@ -330,19 +330,19 @@
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-05-05T08:37:22.526+07:00
-      hippostdpubwf:lastModificationDate: 2021-05-05T10:23:58.567+07:00
+      hippostdpubwf:lastModificationDate: 2021-11-26T08:32:25.615Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: b9db01d7-c4b0-4fc3-bd8a-9b5202d47f02
       hippotranslation:locale: en
       /page0:
         jcr:primaryType: eforms:page
-        jcr:uuid: 557e53e0-653e-4858-a17b-8133e4b3d240
+        jcr:uuid: ac10397b-4bee-47ff-bfd0-fdb48fc5cdf4
         eforms:conditional: false
         eforms:conditionnegate: false
         eforms:label: Page 1
         /field0:
           jcr:primaryType: eforms:textarea
-          jcr:uuid: 63f7c945-981a-409a-8c9d-3620c4727f3c
+          jcr:uuid: 82c736c6-a361-4ffd-86b2-a3719005d8fa
           eforms:cols: 40
           eforms:conditional: false
           eforms:conditionnegate: false
@@ -356,7 +356,7 @@
           eforms:validexpression: ''
         /field1:
           jcr:primaryType: eforms:textfield
-          jcr:uuid: ce7decc7-75d9-47d4-84b7-fb1fee213c40
+          jcr:uuid: cd3fede4-2c69-43f4-b2c9-d206ce3f0bb3
           eforms:conditional: false
           eforms:conditionnegate: false
           eforms:fieldid: id978631fab1d1fafd
@@ -369,7 +369,7 @@
           eforms:validexpression: ''
         /field2:
           jcr:primaryType: eforms:textfield
-          jcr:uuid: 3f3bbba6-c1c3-49c5-a90f-bce2918aecb4
+          jcr:uuid: a8b32ff1-3728-475b-a6e6-f02e4a12181d
           eforms:conditional: false
           eforms:conditionnegate: false
           eforms:fieldid: idbb0577bef97b7753
@@ -382,7 +382,7 @@
           eforms:validexpression: ''
         /field3:
           jcr:primaryType: eforms:textfield
-          jcr:uuid: 464f7024-ecb5-4e5e-9d4a-5c66a231633d
+          jcr:uuid: 95f260fa-75cc-43d3-b19a-cfe34437d9cd
           eforms:autocomplete: ''
           eforms:conditional: false
           eforms:conditionnegate: false
@@ -395,6 +395,86 @@
           eforms:mandatory: false
           eforms:validcasesensitive: 'false'
           eforms:validexpression: ''
+      /emailconfiguration0:
+        jcr:primaryType: eforms:formconfiguration
+        jcr:uuid: 8dc637f7-3850-45d8-904c-ad62ea8ceb90
+        eforms:addattachments: 'false'
+        eforms:mailformdata: 'true'
+        eforms:notificationbccemail: ''
+        eforms:notificationccemail: ''
+        eforms:notificationreplytoemailfields: ''
+        eforms:notificationsubject: Blog comment moderation notification
+        eforms:notificationtemplate: "<#--\r\n  Extended from [hippo-addon-eforms-hst-14.6.3]\
+          \ com.onehippo.cms7:hippo-addon-eforms:14.6.3:com/onehippo/cms7/eforms/hst/templates/email/eforms_html.ftl\r\
+          \n  -->\r\n<#-- @ftlvariable name=\"form\" type=\"com.onehippo.cms7.eforms.hst.model.Form\"\
+          \ -->\r\n<#-- @ftlvariable name=\"paragraph\" type=\"java.lang.String\"\
+          \ -->\r\n<#-- @ftlvariable name=\"includeFieldData\" type=\"java.lang.Boolean\"\
+          \ -->\r\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"\
+          >\r\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\r\n    <#function getRadioGroupValue\
+          \ field>\r\n    <#-- @ftlvariable name=\"field\" type=\"com.onehippo.cms7.eforms.hst.model.AbstractField\"\
+          \ -->\r\n        <#list field.unescapedMultiValues?keys as key>\r\n    \
+          \        <#if key = field.label>\r\n                <#assign collection\
+          \ = field.unescapedMultiValues[key]>\r\n                <#if collection[0]??>\r\
+          \n                    <#return (field.getDisplayValue(collection[0]))!collection[0]>\r\
+          \n                </#if>\r\n            </#if>\r\n        </#list>\r\n \
+          \       <#return \"\">\r\n    </#function>\r\n\r\n    <#macro displayField\
+          \ field ancestor>\r\n        <#-- @ftlvariable name=\"field\" type=\"com.onehippo.cms7.eforms.hst.model.AbstractField\"\
+          \ -->\r\n        <#if !ancestor.conditional || form.checkCondition(ancestor)>\r\
+          \n            <#if !field.conditional || form.checkCondition(field)>\r\n\
+          \                <#if field.multiple>\r\n                    <#if field.type\
+          \ == \"checkboxgroup\">\r\n                    <tr>\r\n                \
+          \        <td colspan=\"2\">${field.labelOrName}</td>\r\n               \
+          \     </tr>\r\n                        <#if field.unescapedMultiValues[field.label]??>\r\
+          \n                            <#list field.unescapedMultiValues[field.label]\
+          \ as checkedValue>\r\n                              <tr>\r\n           \
+          \                     <td></td>\r\n                                <td>${(field.getDisplayValue(checkedValue))!checkedValue}</td>\r\
+          \n                              </tr>\r\n                            </#list>\r\
+          \n                        </#if>\r\n                    <#else>\r\n    \
+          \                <tr><td colspan=\"2\">\r\n                        <table>\r\
+          \n                            <#assign multiValues = field.unescapedMultiValues>\r\
+          \n                            <thead>\r\n                            <tr><th\
+          \ align=\"left\" colspan=\"2\">${field.labelOrName}</th></tr>\r\n      \
+          \                      </thead>\r\n                            <tbody>\r\
+          \n                                <#list multiValues?keys as key>\r\n  \
+          \                              <tr>\r\n                                \
+          \    <td>${key}</td>\r\n                                    <#assign collection\
+          \ = multiValues[key]>\r\n                                    <#list collection\
+          \ as itemValue>\r\n                                        <td>${(field.getDisplayValue(itemValue))!itemValue}</td>\r\
+          \n                                    </#list>\r\n                     \
+          \           </tr>\r\n                                </#list>\r\n      \
+          \                      </tbody>\r\n                        </table>\r\n\
+          \                    </td></tr>\r\n                    </#if>\r\n      \
+          \          <#elseif field.type == \"simpletextfield\">\r\n             \
+          \       <tr>\r\n                        <td colspan=\"2\">${field.labelOrName}</td>\r\
+          \n                    </tr>\r\n                <#else>\r\n             \
+          \       <tr>\r\n                        <td>${field.labelOrName}</td>\r\n\
+          \                        <#if field.type == \"radiogroup\">\r\n        \
+          \                    <td>${getRadioGroupValue(field)}</td>\r\n         \
+          \               <#else>\r\n                            <#if field.unescapedValue??>\r\
+          \n                                <td>${(field.getDisplayValue(field.unescapedValue))!field.unescapedValue}</td>\r\
+          \n                            <#else>\r\n                              \
+          \  <td></td>\r\n                            </#if>\r\n                 \
+          \       </#if>\r\n                    </tr>\r\n                </#if>\r\n\
+          \            </#if>\r\n        </#if>\r\n    </#macro>\r\n\r\n    <head>\r\
+          \n        <meta http-equiv=\"content-type\" content=\"text/html;charset=UTF-8\"\
+          />\r\n        <title>Blog comment moderation notification</title>\r\n  \
+          \  </head>\r\n    <body>\r\n        <#if paragraph??>\r\n            <p>${paragraph}</p>\r\
+          \n        </#if>\r\n        <#if includeFieldData>\r\n        <table>\r\n\
+          \            <#list form.pages as page>\r\n                <#list page.fields\
+          \ as field>\r\n                    <#assign fieldType = field.type>\r\n\
+          \                    <#if fieldType == 'fieldgroup'>\r\n               \
+          \         <#if !field.conditional || form.checkCondition(field)>\r\n   \
+          \                         <tr><th align=\"left\" colspan=\"2\">${field.labelOrName}</th></tr>\r\
+          \n                            <#list field.fields as groupField>\r\n   \
+          \                             <@displayField field=groupField ancestor=field/>\r\
+          \n                            </#list>\r\n                        </#if>\r\
+          \n                    <#else>\r\n                        <@displayField\
+          \ field=field ancestor=page/>\r\n                    </#if>\r\n        \
+          \        </#list>\r\n            </#list>\r\n        </table>\r\n      \
+          \  </#if>\r\n    </body>\r\n</html>"
+        eforms:notificationtext: "Hi,\r\n\r\nPlease moderate the following comment\
+          \ that has recently been added by a visitor to the ##BLOG_POST_DOCUMENT##\
+          \ blog post document:"
     /blogcomment[2]:
       jcr:primaryType: eforms:form
       jcr:mixinTypes: ['hippotranslation:translated', 'mix:referenceable', 'mix:versionable']
@@ -413,19 +493,19 @@
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-05-05T08:37:22.526+07:00
-      hippostdpubwf:lastModificationDate: 2021-05-05T10:24:15.385+07:00
+      hippostdpubwf:lastModificationDate: 2021-11-26T08:32:37.475Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: b9db01d7-c4b0-4fc3-bd8a-9b5202d47f02
       hippotranslation:locale: en
       /page0:
         jcr:primaryType: eforms:page
-        jcr:uuid: 31d8e933-bd77-4297-86cc-dc3390af4ce6
+        jcr:uuid: 83fc5a9f-dedd-4cb3-a830-0419e4b634ce
         eforms:conditional: false
         eforms:conditionnegate: false
         eforms:label: Page 1
         /field0:
           jcr:primaryType: eforms:textarea
-          jcr:uuid: dd188e4f-6303-4825-87ba-a3f345231ebe
+          jcr:uuid: 98c424b8-b34e-4cb9-9afa-9698321df355
           eforms:cols: 40
           eforms:conditional: false
           eforms:conditionnegate: false
@@ -439,7 +519,7 @@
           eforms:validexpression: ''
         /field1:
           jcr:primaryType: eforms:textfield
-          jcr:uuid: 9f5b1ca9-3e8e-4f2b-a28b-4c0059a1f871
+          jcr:uuid: 7887613a-6f31-400e-bad8-770bdefbefbc
           eforms:conditional: false
           eforms:conditionnegate: false
           eforms:fieldid: id978631fab1d1fafd
@@ -452,7 +532,7 @@
           eforms:validexpression: ''
         /field2:
           jcr:primaryType: eforms:textfield
-          jcr:uuid: a31d8ead-1914-4ca5-82b4-00a319337c33
+          jcr:uuid: 5616bfeb-d27a-4df0-b5ae-e23f7b1fff9e
           eforms:conditional: false
           eforms:conditionnegate: false
           eforms:fieldid: idbb0577bef97b7753
@@ -465,7 +545,7 @@
           eforms:validexpression: ''
         /field3:
           jcr:primaryType: eforms:textfield
-          jcr:uuid: 17cd5a55-9bb1-48e8-8278-2073cb2402cc
+          jcr:uuid: ce915ed9-5579-46e7-9ae3-55465b86bbff
           eforms:autocomplete: ''
           eforms:conditional: false
           eforms:conditionnegate: false
@@ -478,6 +558,86 @@
           eforms:mandatory: false
           eforms:validcasesensitive: 'false'
           eforms:validexpression: ''
+      /emailconfiguration0:
+        jcr:primaryType: eforms:formconfiguration
+        jcr:uuid: 9c4c40db-5fca-4e94-b67b-95af6a6127cf
+        eforms:addattachments: 'false'
+        eforms:mailformdata: 'true'
+        eforms:notificationbccemail: ''
+        eforms:notificationccemail: ''
+        eforms:notificationreplytoemailfields: ''
+        eforms:notificationsubject: Blog comment moderation notification
+        eforms:notificationtemplate: "<#--\r\n  Extended from [hippo-addon-eforms-hst-14.6.3]\
+          \ com.onehippo.cms7:hippo-addon-eforms:14.6.3:com/onehippo/cms7/eforms/hst/templates/email/eforms_html.ftl\r\
+          \n  -->\r\n<#-- @ftlvariable name=\"form\" type=\"com.onehippo.cms7.eforms.hst.model.Form\"\
+          \ -->\r\n<#-- @ftlvariable name=\"paragraph\" type=\"java.lang.String\"\
+          \ -->\r\n<#-- @ftlvariable name=\"includeFieldData\" type=\"java.lang.Boolean\"\
+          \ -->\r\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"\
+          >\r\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\r\n    <#function getRadioGroupValue\
+          \ field>\r\n    <#-- @ftlvariable name=\"field\" type=\"com.onehippo.cms7.eforms.hst.model.AbstractField\"\
+          \ -->\r\n        <#list field.unescapedMultiValues?keys as key>\r\n    \
+          \        <#if key = field.label>\r\n                <#assign collection\
+          \ = field.unescapedMultiValues[key]>\r\n                <#if collection[0]??>\r\
+          \n                    <#return (field.getDisplayValue(collection[0]))!collection[0]>\r\
+          \n                </#if>\r\n            </#if>\r\n        </#list>\r\n \
+          \       <#return \"\">\r\n    </#function>\r\n\r\n    <#macro displayField\
+          \ field ancestor>\r\n        <#-- @ftlvariable name=\"field\" type=\"com.onehippo.cms7.eforms.hst.model.AbstractField\"\
+          \ -->\r\n        <#if !ancestor.conditional || form.checkCondition(ancestor)>\r\
+          \n            <#if !field.conditional || form.checkCondition(field)>\r\n\
+          \                <#if field.multiple>\r\n                    <#if field.type\
+          \ == \"checkboxgroup\">\r\n                    <tr>\r\n                \
+          \        <td colspan=\"2\">${field.labelOrName}</td>\r\n               \
+          \     </tr>\r\n                        <#if field.unescapedMultiValues[field.label]??>\r\
+          \n                            <#list field.unescapedMultiValues[field.label]\
+          \ as checkedValue>\r\n                              <tr>\r\n           \
+          \                     <td></td>\r\n                                <td>${(field.getDisplayValue(checkedValue))!checkedValue}</td>\r\
+          \n                              </tr>\r\n                            </#list>\r\
+          \n                        </#if>\r\n                    <#else>\r\n    \
+          \                <tr><td colspan=\"2\">\r\n                        <table>\r\
+          \n                            <#assign multiValues = field.unescapedMultiValues>\r\
+          \n                            <thead>\r\n                            <tr><th\
+          \ align=\"left\" colspan=\"2\">${field.labelOrName}</th></tr>\r\n      \
+          \                      </thead>\r\n                            <tbody>\r\
+          \n                                <#list multiValues?keys as key>\r\n  \
+          \                              <tr>\r\n                                \
+          \    <td>${key}</td>\r\n                                    <#assign collection\
+          \ = multiValues[key]>\r\n                                    <#list collection\
+          \ as itemValue>\r\n                                        <td>${(field.getDisplayValue(itemValue))!itemValue}</td>\r\
+          \n                                    </#list>\r\n                     \
+          \           </tr>\r\n                                </#list>\r\n      \
+          \                      </tbody>\r\n                        </table>\r\n\
+          \                    </td></tr>\r\n                    </#if>\r\n      \
+          \          <#elseif field.type == \"simpletextfield\">\r\n             \
+          \       <tr>\r\n                        <td colspan=\"2\">${field.labelOrName}</td>\r\
+          \n                    </tr>\r\n                <#else>\r\n             \
+          \       <tr>\r\n                        <td>${field.labelOrName}</td>\r\n\
+          \                        <#if field.type == \"radiogroup\">\r\n        \
+          \                    <td>${getRadioGroupValue(field)}</td>\r\n         \
+          \               <#else>\r\n                            <#if field.unescapedValue??>\r\
+          \n                                <td>${(field.getDisplayValue(field.unescapedValue))!field.unescapedValue}</td>\r\
+          \n                            <#else>\r\n                              \
+          \  <td></td>\r\n                            </#if>\r\n                 \
+          \       </#if>\r\n                    </tr>\r\n                </#if>\r\n\
+          \            </#if>\r\n        </#if>\r\n    </#macro>\r\n\r\n    <head>\r\
+          \n        <meta http-equiv=\"content-type\" content=\"text/html;charset=UTF-8\"\
+          />\r\n        <title>Blog comment moderation notification</title>\r\n  \
+          \  </head>\r\n    <body>\r\n        <#if paragraph??>\r\n            <p>${paragraph}</p>\r\
+          \n        </#if>\r\n        <#if includeFieldData>\r\n        <table>\r\n\
+          \            <#list form.pages as page>\r\n                <#list page.fields\
+          \ as field>\r\n                    <#assign fieldType = field.type>\r\n\
+          \                    <#if fieldType == 'fieldgroup'>\r\n               \
+          \         <#if !field.conditional || form.checkCondition(field)>\r\n   \
+          \                         <tr><th align=\"left\" colspan=\"2\">${field.labelOrName}</th></tr>\r\
+          \n                            <#list field.fields as groupField>\r\n   \
+          \                             <@displayField field=groupField ancestor=field/>\r\
+          \n                            </#list>\r\n                        </#if>\r\
+          \n                    <#else>\r\n                        <@displayField\
+          \ field=field ancestor=page/>\r\n                    </#if>\r\n        \
+          \        </#list>\r\n            </#list>\r\n        </table>\r\n      \
+          \  </#if>\r\n    </body>\r\n</html>"
+        eforms:notificationtext: "Hi,\r\n\r\nPlease moderate the following comment\
+          \ that has recently been added by a visitor to the ##BLOG_POST_DOCUMENT##\
+          \ blog post document:"
     /blogcomment[3]:
       jcr:primaryType: eforms:form
       jcr:mixinTypes: ['hippotranslation:translated', 'mix:referenceable']
@@ -496,20 +656,20 @@
       hippostd:state: published
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-05-05T08:37:22.526+07:00
-      hippostdpubwf:lastModificationDate: 2021-05-05T10:24:15.385+07:00
+      hippostdpubwf:lastModificationDate: 2021-11-26T08:32:37.475Z
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2021-05-05T10:24:17.165+07:00
+      hippostdpubwf:publicationDate: 2021-11-26T08:32:40.114Z
       hippotranslation:id: b9db01d7-c4b0-4fc3-bd8a-9b5202d47f02
       hippotranslation:locale: en
       /page0:
         jcr:primaryType: eforms:page
-        jcr:uuid: e0ef544f-3857-44be-93d2-b21d52554ab2
+        jcr:uuid: 07e236da-18ce-47c6-adfd-e8abc4847754
         eforms:conditional: false
         eforms:conditionnegate: false
         eforms:label: Page 1
         /field0:
           jcr:primaryType: eforms:textarea
-          jcr:uuid: 5d446043-c66d-436b-9e58-fb30d7dbdd7c
+          jcr:uuid: 4c4564cc-0a09-4571-a63c-3f0d6c1a874a
           eforms:cols: 40
           eforms:conditional: false
           eforms:conditionnegate: false
@@ -523,7 +683,7 @@
           eforms:validexpression: ''
         /field1:
           jcr:primaryType: eforms:textfield
-          jcr:uuid: 18095035-2bcf-4f12-ac9a-8591ddc46522
+          jcr:uuid: ad6d1d16-3141-4d80-a99f-923e788e7be5
           eforms:conditional: false
           eforms:conditionnegate: false
           eforms:fieldid: id978631fab1d1fafd
@@ -536,7 +696,7 @@
           eforms:validexpression: ''
         /field2:
           jcr:primaryType: eforms:textfield
-          jcr:uuid: d717cbbe-6a03-4ba5-aa46-0134739a2260
+          jcr:uuid: dbb7598d-e926-473a-9ec6-3f636012e534
           eforms:conditional: false
           eforms:conditionnegate: false
           eforms:fieldid: idbb0577bef97b7753
@@ -549,7 +709,7 @@
           eforms:validexpression: ''
         /field3:
           jcr:primaryType: eforms:textfield
-          jcr:uuid: 5f68ed07-548c-481f-85ad-0edcbe252df4
+          jcr:uuid: a5f4e7cd-87b0-4a29-9241-cadc51144afc
           eforms:autocomplete: ''
           eforms:conditional: false
           eforms:conditionnegate: false
@@ -562,3 +722,83 @@
           eforms:mandatory: false
           eforms:validcasesensitive: 'false'
           eforms:validexpression: ''
+      /emailconfiguration0:
+        jcr:primaryType: eforms:formconfiguration
+        jcr:uuid: 46849a35-a86e-4f9d-b070-5b8d1f6d74c2
+        eforms:addattachments: 'false'
+        eforms:mailformdata: 'true'
+        eforms:notificationbccemail: ''
+        eforms:notificationccemail: ''
+        eforms:notificationreplytoemailfields: ''
+        eforms:notificationsubject: Blog comment moderation notification
+        eforms:notificationtemplate: "<#--\r\n  Extended from [hippo-addon-eforms-hst-14.6.3]\
+          \ com.onehippo.cms7:hippo-addon-eforms:14.6.3:com/onehippo/cms7/eforms/hst/templates/email/eforms_html.ftl\r\
+          \n  -->\r\n<#-- @ftlvariable name=\"form\" type=\"com.onehippo.cms7.eforms.hst.model.Form\"\
+          \ -->\r\n<#-- @ftlvariable name=\"paragraph\" type=\"java.lang.String\"\
+          \ -->\r\n<#-- @ftlvariable name=\"includeFieldData\" type=\"java.lang.Boolean\"\
+          \ -->\r\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"\
+          >\r\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\r\n    <#function getRadioGroupValue\
+          \ field>\r\n    <#-- @ftlvariable name=\"field\" type=\"com.onehippo.cms7.eforms.hst.model.AbstractField\"\
+          \ -->\r\n        <#list field.unescapedMultiValues?keys as key>\r\n    \
+          \        <#if key = field.label>\r\n                <#assign collection\
+          \ = field.unescapedMultiValues[key]>\r\n                <#if collection[0]??>\r\
+          \n                    <#return (field.getDisplayValue(collection[0]))!collection[0]>\r\
+          \n                </#if>\r\n            </#if>\r\n        </#list>\r\n \
+          \       <#return \"\">\r\n    </#function>\r\n\r\n    <#macro displayField\
+          \ field ancestor>\r\n        <#-- @ftlvariable name=\"field\" type=\"com.onehippo.cms7.eforms.hst.model.AbstractField\"\
+          \ -->\r\n        <#if !ancestor.conditional || form.checkCondition(ancestor)>\r\
+          \n            <#if !field.conditional || form.checkCondition(field)>\r\n\
+          \                <#if field.multiple>\r\n                    <#if field.type\
+          \ == \"checkboxgroup\">\r\n                    <tr>\r\n                \
+          \        <td colspan=\"2\">${field.labelOrName}</td>\r\n               \
+          \     </tr>\r\n                        <#if field.unescapedMultiValues[field.label]??>\r\
+          \n                            <#list field.unescapedMultiValues[field.label]\
+          \ as checkedValue>\r\n                              <tr>\r\n           \
+          \                     <td></td>\r\n                                <td>${(field.getDisplayValue(checkedValue))!checkedValue}</td>\r\
+          \n                              </tr>\r\n                            </#list>\r\
+          \n                        </#if>\r\n                    <#else>\r\n    \
+          \                <tr><td colspan=\"2\">\r\n                        <table>\r\
+          \n                            <#assign multiValues = field.unescapedMultiValues>\r\
+          \n                            <thead>\r\n                            <tr><th\
+          \ align=\"left\" colspan=\"2\">${field.labelOrName}</th></tr>\r\n      \
+          \                      </thead>\r\n                            <tbody>\r\
+          \n                                <#list multiValues?keys as key>\r\n  \
+          \                              <tr>\r\n                                \
+          \    <td>${key}</td>\r\n                                    <#assign collection\
+          \ = multiValues[key]>\r\n                                    <#list collection\
+          \ as itemValue>\r\n                                        <td>${(field.getDisplayValue(itemValue))!itemValue}</td>\r\
+          \n                                    </#list>\r\n                     \
+          \           </tr>\r\n                                </#list>\r\n      \
+          \                      </tbody>\r\n                        </table>\r\n\
+          \                    </td></tr>\r\n                    </#if>\r\n      \
+          \          <#elseif field.type == \"simpletextfield\">\r\n             \
+          \       <tr>\r\n                        <td colspan=\"2\">${field.labelOrName}</td>\r\
+          \n                    </tr>\r\n                <#else>\r\n             \
+          \       <tr>\r\n                        <td>${field.labelOrName}</td>\r\n\
+          \                        <#if field.type == \"radiogroup\">\r\n        \
+          \                    <td>${getRadioGroupValue(field)}</td>\r\n         \
+          \               <#else>\r\n                            <#if field.unescapedValue??>\r\
+          \n                                <td>${(field.getDisplayValue(field.unescapedValue))!field.unescapedValue}</td>\r\
+          \n                            <#else>\r\n                              \
+          \  <td></td>\r\n                            </#if>\r\n                 \
+          \       </#if>\r\n                    </tr>\r\n                </#if>\r\n\
+          \            </#if>\r\n        </#if>\r\n    </#macro>\r\n\r\n    <head>\r\
+          \n        <meta http-equiv=\"content-type\" content=\"text/html;charset=UTF-8\"\
+          />\r\n        <title>Blog comment moderation notification</title>\r\n  \
+          \  </head>\r\n    <body>\r\n        <#if paragraph??>\r\n            <p>${paragraph}</p>\r\
+          \n        </#if>\r\n        <#if includeFieldData>\r\n        <table>\r\n\
+          \            <#list form.pages as page>\r\n                <#list page.fields\
+          \ as field>\r\n                    <#assign fieldType = field.type>\r\n\
+          \                    <#if fieldType == 'fieldgroup'>\r\n               \
+          \         <#if !field.conditional || form.checkCondition(field)>\r\n   \
+          \                         <tr><th align=\"left\" colspan=\"2\">${field.labelOrName}</th></tr>\r\
+          \n                            <#list field.fields as groupField>\r\n   \
+          \                             <@displayField field=groupField ancestor=field/>\r\
+          \n                            </#list>\r\n                        </#if>\r\
+          \n                    <#else>\r\n                        <@displayField\
+          \ field=field ancestor=page/>\r\n                    </#if>\r\n        \
+          \        </#list>\r\n            </#list>\r\n        </table>\r\n      \
+          \  </#if>\r\n    </body>\r\n</html>"
+        eforms:notificationtext: "Hi,\r\n\r\nPlease moderate the following comment\
+          \ that has recently been added by a visitor to the ##BLOG_POST_DOCUMENT##\
+          \ blog post document:"

--- a/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/pages/expert-searching-blog-page.yaml
+++ b/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/pages/expert-searching-blog-page.yaml
@@ -35,7 +35,7 @@
           eforms-from-name, eforms-from-email]
         hst:parametervalues: [/content/documents/lks/forms/blogcomment, 'com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior,
             uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior, uk.nhs.hee.web.eforms.hst.behaviors.BlogPostCommentMailFormDataBehavior',
-          mail/Session, 'true', 'CMS Admin [Dev]', cms.admin.dev@hee.nhs.uk]
+          mail/Session, 'true', 'CMS Admin', cms.admin@hee.nhs.uk]
         hst:resourcetemplate: eforms.validation.default
         hst:template: eforms.default
         hst:xtype: HST.Item

--- a/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/pages/expert-searching-blog-page.yaml
+++ b/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/pages/expert-searching-blog-page.yaml
@@ -6,23 +6,6 @@
     jcr:primaryType: hst:component
     hst:componentclassname: org.onehippo.cms7.essentials.components.EssentialsDocumentComponent
     hst:template: blogpage-main
-    /comment:
-      jcr:primaryType: hst:containercomponent
-      hippo:identifier: 3009ef19-c5f6-4583-876b-e2f0d52941ee
-      hst:label: Comment Form
-      hst:lastmodified: 2021-05-05T09:19:22.498+07:00
-      hst:xtype: hst.vbox
-      /blog-comment-form:
-        jcr:primaryType: hst:containeritemcomponent
-        hst:componentclassname: com.onehippo.cms7.eforms.hst.components.AutoDetectFormComponent
-        hst:iconpath: resources/addon/eforms/images/icons/form.svg
-        hst:label: Enterprise Form
-        hst:parameternames: [form, behaviors]
-        hst:parametervalues: [/content/documents/lks/forms/blogcomment, 'com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior,
-            uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior']
-        hst:resourcetemplate: eforms.validation.default
-        hst:template: eforms.default
-        hst:xtype: HST.Item
     /blog:
       jcr:primaryType: hst:containercomponent
       hippo:identifier: 9c5b2da6-9a3f-4964-8296-ac6af0793859
@@ -37,3 +20,22 @@
         hst:parameternames: [document]
         hst:parametervalues: [blogposts/expertssearch]
         hst:template: blogpost-main
+    /comment:
+      jcr:primaryType: hst:containercomponent
+      hippo:identifier: 3009ef19-c5f6-4583-876b-e2f0d52941ee
+      hst:label: Comment Form
+      hst:lastmodified: 2021-05-05T09:19:22.498+07:00
+      hst:xtype: hst.vbox
+      /blog-comment-form:
+        jcr:primaryType: hst:containeritemcomponent
+        hst:componentclassname: uk.nhs.hee.web.components.eforms.NoAutoDetectFormComponent
+        hst:iconpath: resources/addon/eforms/images/icons/form.svg
+        hst:label: Blog comment form
+        hst:parameternames: [form, behaviors, eforms-mailsession, eforms-use-freemarker,
+          eforms-from-name, eforms-from-email]
+        hst:parametervalues: [/content/documents/lks/forms/blogcomment, 'com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior,
+            uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior, uk.nhs.hee.web.eforms.hst.behaviors.BlogPostCommentMailFormDataBehavior',
+          mail/Session, 'true', 'CMS Admin [Dev]', cms.admin.dev@hee.nhs.uk]
+        hst:resourcetemplate: eforms.validation.default
+        hst:template: eforms.default
+        hst:xtype: HST.Item

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/default/catalog.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/default/catalog.yaml
@@ -7,15 +7,17 @@ definitions:
       hst:parametervalues: [com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior]
     /hst:hst/hst:configurations/hst:default/hst:catalog/eforms-blog-catalog:
       jcr:primaryType: hst:containeritempackage
-      hst:hiddeninchannelmanager: true
+      hst:hiddeninchannelmanager: false
       /blog-comment-form:
         jcr:primaryType: hst:containeritemcomponent
-        hst:componentclassname: com.onehippo.cms7.eforms.hst.components.AutoDetectFormComponent
+        hst:componentclassname: uk.nhs.hee.web.components.eforms.NoAutoDetectFormComponent
         hst:iconpath: resources/addon/eforms/images/icons/form.svg
-        hst:label: Blog Comments Form
-        hst:parameternames: [behaviors]
+        hst:label: Blog Comment Form
+        hst:parameternames: [behaviors, eforms-mailsession, eforms-use-freemarker,
+          eforms-from-name, eforms-from-email]
         hst:parametervalues: ['com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior,
-            uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior']
+            uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior, uk.nhs.hee.web.eforms.hst.behaviors.MailFormDataExtensionBehavior',
+          mail/Session, 'true', 'CMS Admin [Dev]', cms.admin.dev@hee.nhs.uk]
         hst:resourcetemplate: eforms.validation.default
         hst:template: eforms.default
         hst:xtype: HST.Item

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/default/catalog.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/default/catalog.yaml
@@ -17,7 +17,7 @@ definitions:
           eforms-from-name, eforms-from-email]
         hst:parametervalues: ['com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior,
             uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior, uk.nhs.hee.web.eforms.hst.behaviors.MailFormDataExtensionBehavior',
-          mail/Session, 'true', 'CMS Admin [Dev]', cms.admin.dev@hee.nhs.uk]
+          mail/Session, 'true', 'CMS Admin', cms.admin@hee.nhs.uk]
         hst:resourcetemplate: eforms.validation.default
         hst:template: eforms.default
         hst:xtype: HST.Item

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
@@ -118,7 +118,7 @@
 
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-            <h2 data-anchorlinksignore="true">${document.comments?size} <@fmt.message key="comments"/></h2>
+            <h2 data-anchorlinksignore="true">${totalComments} <@fmt.message key="comments"/></h2>
 
             <#if totalComments gt 0>
                 <#assign datePattern = "d MMMM yyyy">
@@ -136,7 +136,7 @@
 
                 <#if totalComments gt 3>
                     <#if totalComments gt visibleComments?size>
-                        <a href="?showAllComments=true"><@fmt.message key="comment.view_all"/> ${document.comments?size} <@fmt.message key="comments"/></a>
+                        <a href="?showAllComments=true"><@fmt.message key="comment.view_all"/> ${totalComments} <@fmt.message key="comments"/></a>
                     <#else>
                         <a href="?showAllComments=false"><@fmt.message key="comment.view_less"/> <@fmt.message key="comments"/></a>
                     </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/blogpage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/blogpage-main.ftl
@@ -6,10 +6,10 @@
 
         <#--  HEE-233: Temporarily switching off the ability to add comment(s) to blog posts
               while the moderation functionality is being developed  -->
-        <#--  <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
+        <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
             <div class="nhsuk-grid-column-two-thirds">
                 <@hst.include ref="comment"/>
             </div>
-        </div>  -->
+        </div>
     </main>
 </div>

--- a/site/components/pom.xml
+++ b/site/components/pom.xml
@@ -78,6 +78,10 @@
       <groupId>com.onehippo.cms7</groupId>
       <artifactId>hippo-addon-urlrewriter-module-hst</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.onehippo.cms7</groupId>
+      <artifactId>hippo-addon-eforms-hst</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/BlogComment.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/BlogComment.java
@@ -23,4 +23,9 @@ public class BlogComment extends HippoCompound {
     public Calendar getPostedDate() {
         return getSingleProperty("hee:postedDate");
     }
+
+    @HippoEssentialsGenerated(internalName = "hee:moderated")
+    public Boolean getModerated() {
+        return getSingleProperty("hee:moderated");
+    }
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/components/BlogPostComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/BlogPostComponent.java
@@ -35,7 +35,7 @@ public class BlogPostComponent extends EssentialsDocumentComponent {
 
             addBlogListingPageURLToModel(request);
 
-            final List<BlogComment> comments = blogPost.getComments();
+            final List<BlogComment> comments = getModeratedComments(blogPost.getComments());
             request.setModel("totalComments", comments.size());
 
             if (comments.isEmpty()) {
@@ -95,6 +95,18 @@ public class BlogPostComponent extends EssentialsDocumentComponent {
                 blogCategories.stream()
                         .filter(category -> allBlogCategoriesValueListMap.get(category) != null)
                         .collect(Collectors.toMap(category -> category, allBlogCategoriesValueListMap::get)));
+    }
+
+    /**
+     * Returns moderated comments i.e. the comments whose {@code hee:moderated} property is {@code true}.
+     *
+     * @param comments the list of all blog comments.
+     * @return the moderated comments.
+     */
+    private List<BlogComment> getModeratedComments(final List<BlogComment> comments) {
+        return comments.stream()
+                .filter(comment -> Boolean.TRUE.equals(comment.getModerated()))
+                .collect(Collectors.toList());
     }
 
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/components/eforms/NoAutoDetectFormComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/eforms/NoAutoDetectFormComponent.java
@@ -1,0 +1,26 @@
+package uk.nhs.hee.web.components.eforms;
+
+import com.onehippo.cms7.eforms.hst.components.AutoDetectFormComponent;
+import com.onehippo.cms7.eforms.hst.components.info.AutoDetectFormComponentInfo;
+import org.apache.commons.lang3.ArrayUtils;
+import org.hippoecm.hst.core.parameters.ParametersInfo;
+
+/**
+ * An extension of {@link AutoDetectFormComponent} which overrides default behaviors
+ * with an empty one (@{ArrayUtils.EMPTY_CLASS_ARRAY}) so that it wouldn't auto-detect behaviors
+ * by checking the underlying form document instance, that was picked in the Channel Manager.
+ *
+ * This will let components using this class define behaviors and its order using the {@code behaviors} parameter name
+ * (without including default behaviors automatically).
+ */
+@ParametersInfo(type = AutoDetectFormComponentInfo.class)
+public class NoAutoDetectFormComponent extends AutoDetectFormComponent {
+
+    /**
+     * An override of {@link AutoDetectFormComponent#getAutoDetectBehaviors()} returning an empty {@link Class} array.
+     */
+    @Override
+    protected Class[] getAutoDetectBehaviors() {
+        return ArrayUtils.EMPTY_CLASS_ARRAY;
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/eforms/hst/behaviors/BlogPostCommentMailFormDataBehavior.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/eforms/hst/behaviors/BlogPostCommentMailFormDataBehavior.java
@@ -1,0 +1,222 @@
+package uk.nhs.hee.web.eforms.hst.behaviors;
+
+import com.onehippo.cms7.eforms.hst.behaviors.MailFormDataBehavior;
+import com.onehippo.cms7.eforms.hst.model.Form;
+import com.onehippo.cms7.eforms.hst.util.FormVariableParser;
+import com.onehippo.cms7.eforms.hst.util.mail.MailSender;
+import com.onehippo.cms7.eforms.hst.util.mail.MailTemplate;
+import org.apache.commons.lang3.StringUtils;
+import org.hippoecm.hst.component.support.forms.FormMap;
+import org.hippoecm.hst.configuration.components.HstComponentConfiguration;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.content.beans.standard.HippoItem;
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.request.ComponentConfiguration;
+import org.hippoecm.hst.util.HstRequestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.nhs.hee.web.beans.BlogPost;
+
+import javax.mail.Address;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+/**
+ * An extension of {@link MailFormDataBehavior} for BlogPost Comment form
+ * to replace {@code ##BLOG_POST_DOCUMENT##} placeholder with blog post ({@code hee:blogPost}) document CMS link
+ * to which the comment has been submitted to.
+ */
+public class BlogPostCommentMailFormDataBehavior extends MailFormDataBehavior {
+
+    // Blog post document email text placeholder
+    public static final String BLOG_POST_DOCUMENT_EMAIL_TEXT_PLACEHOLDER = "##BLOG_POST_DOCUMENT##";
+    // Logger
+    private static final Logger log = LoggerFactory.getLogger(BlogPostCommentMailFormDataBehavior.class);
+
+    /**
+     * An override of
+     * {@link MailFormDataBehavior#createMailTemplate(
+     *      org.hippoecm.hst.core.component.HstRequest,
+     *      org.hippoecm.hst.core.request.ComponentConfiguration,
+     *      com.onehippo.cms7.eforms.hst.model.Form,
+     *      org.hippoecm.hst.component.support.forms.FormMap,
+     *      java.util.List,
+     *      java.util.List,
+     *      java.util.List,
+     *      com.onehippo.cms7.eforms.hst.util.mail.MailSender,
+     *      org.hippoecm.hst.content.beans.standard.HippoItem)}
+     * which replaces {@code ##BLOG_POST_DOCUMENT##} placeholders on both plaintext and html
+     * with blog post ({@code hee:blogPost}) document CMS link to which the comment has been submitted to.
+     */
+    @Override
+    protected MailTemplate createMailTemplate(
+            final HstRequest request,
+            final ComponentConfiguration config,
+            final Form form,
+            final FormMap map,
+            final List<Address> recipients,
+            final List<Address> ccRecipients,
+            final List<Address> bccRecipients,
+            final MailSender sender,
+            final HippoItem bean) {
+        final String subject = FormVariableParser.parse(getSubject(request, config, bean, ""), map);
+        final String mailText = bean.getSingleProperty(PROP_NAME_NOTIFICATIONTEXT);
+        final String template = bean.getSingleProperty(PROP_NAME_NOTIFICATIONTEMPLATE);
+
+        String plainText = getPlainText(request, config, form, map, mailText, true);
+        String html = createHTMLContent(request, config, form, map, mailText, template);
+
+        final BlogPost blogPost = getBlogPost(request, config);
+
+        if (blogPost != null) {
+            log.debug("Blog post (hee:blogPost) document absolute path = {}", blogPost.getPath());
+
+            plainText = updateBlogPostPlaceholders(request, blogPost, plainText, false);
+            html = updateBlogPostPlaceholders(request, blogPost, html, true);
+        }
+
+        return new MailTemplate(sender, recipients, ccRecipients, bccRecipients, subject, html, plainText);
+    }
+
+    /**
+     * Duplicated from
+     * {@link MailFormDataBehavior#createHTMLContent(
+     *      org.hippoecm.hst.core.component.HstRequest,
+     *      org.hippoecm.hst.core.request.ComponentConfiguration,
+     *      com.onehippo.cms7.eforms.hst.model.Form,
+     *      org.hippoecm.hst.component.support.forms.FormMap,
+     *      java.lang.String,
+     *      java.lang.String)}
+     * as it is a private method.
+     */
+    private String createHTMLContent(final HstRequest request,
+                                     final ComponentConfiguration config,
+                                     final Form form,
+                                     final FormMap map,
+                                     final String mailText,
+                                     final String template) {
+        if (StringUtils.isEmpty(template)) {
+            return getHtml(request, config, form, map, mailText, true);
+        } else {
+            return getHtml(request, config, form, map, mailText, true, template);
+        }
+    }
+
+    /**
+     * <p>Returns blog post document {@code hee:blogPost} relative path based
+     * on the given blog comment component {@code config} instance.</p>
+     *
+     * <p>It does this by navigating to {@code blogpost} component from the given {@code config} instance
+     * and returns the value of {@code document} parameter.</p>
+     *
+     * @param config the blog comment {@link ComponentConfiguration} instance.
+     * @return the blog post document {@code hee:blogPost} relative path.
+     */
+    private String getBlogPostDocumentRelativePath(final ComponentConfiguration config) {
+        try {
+            final HstComponentConfiguration commentComponentConfig = (HstComponentConfiguration) config.getClass()
+                    .getMethod("getComponentConfiguration").invoke(config);
+            return commentComponentConfig.getParent().getParent().getChildByName("blog").getChildByName("blogpost")
+                    .getParameter("document");
+        } catch (final IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            log.error("Caught error {} while getting blog post (hee:blogPost) document relative path " +
+                    "from comment form component config.", e.getMessage(), e);
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    /**
+     * Returns {@link BlogPost} instance of the {@code hee:blogPost} document
+     * to which the given blog comment component {@code config} instance is associated to.
+     *
+     * @param request the {@link HstRequest} instance.
+     * @param config the blog comment {@link ComponentConfiguration} instance.
+     * @return the {@link BlogPost} instance of the {@code hee:blogPost} document
+     * to which the given blog comment component {@code config} instance is associated to.
+     */
+    private BlogPost getBlogPost(final HstRequest request, final ComponentConfiguration config) {
+        final String blogPostDocumentRelativePath = getBlogPostDocumentRelativePath(config);
+        log.debug("Blog post (hee:blogPost) document relative path = {}", blogPostDocumentRelativePath);
+
+        if (StringUtils.isEmpty(blogPostDocumentRelativePath)) {
+            return null;
+        }
+
+        final HippoBean root = request.getRequestContext().getSiteContentBaseBean();
+        return root.getBean(blogPostDocumentRelativePath);
+    }
+
+    /**
+     * <p>Returns CMS document URL of the given {@code documentPath}</p>.
+     *
+     * <p>It constructs the CMS document URL using {@code [CMS_URL]/content/path/[JCR_DOCUMENT_PATH]} pattern.</p>
+     *
+     * @param request the {@link HstRequest} instance.
+     * @param documentPath the canonical (JCR) document path.
+     * @return the CMS document URL of the given {@code documentPath}.
+     */
+    private String getDocumentURL(final HstRequest request, final String documentPath) {
+        return HstRequestUtils.getCmsBaseURL(request) + "/content/path" + documentPath;
+    }
+
+    /**
+     * Replaces {@code ##BLOG_POST_DOCUMENT##} placeholders on the given {@code htmlOrPlainText}
+     * with blog post ({@code hee:blogPost}) document CMS link to which the comment has been submitted to.
+     *
+     * @param request the {@link HstRequest} instance.
+     * @param blogPost the {@link BlogPost} instance of the {@code hee:blogPost} document
+     *                 to which the comment has been submitted to.
+     * @param htmlOrPlainText the HTML or the plain text in which {@code ##BLOG_POST_DOCUMENT##} placeholders
+     *                        needs to be updated with blog post ({@code hee:blogPost}) document CMS link
+     *                        to which the comment has been submitted to.
+     * @param isHTML the boolean indicating whether the given {@code htmlOrPlainText} is an HTML or plaintext.
+     * @return the updated {@code htmlOrPlainText} in which instances of {@code ##BLOG_POST_DOCUMENT##} placeholders
+     * has been replaced with blog post ({@code hee:blogPost}) document CMS link
+     * to which the comment has been submitted to.
+     */
+    private String updateBlogPostPlaceholders(
+            final HstRequest request,
+            final BlogPost blogPost,
+            final String htmlOrPlainText,
+            final boolean isHTML) {
+        final String blogPostDocumentCMSURL = getDocumentURL(request, blogPost.getPath());
+
+        final String blogpostDocumentLink;
+        if (isHTML) {
+            blogpostDocumentLink = getBlogpostDocumentLinkForHTML(blogPost, blogPostDocumentCMSURL);
+        } else {
+            blogpostDocumentLink = getBlogpostDocumentLinkForPlainText(blogPost, blogPostDocumentCMSURL);
+        }
+
+        return htmlOrPlainText.replace(BLOG_POST_DOCUMENT_EMAIL_TEXT_PLACEHOLDER, blogpostDocumentLink);
+    }
+
+    /**
+     * Returns blog post document link for plaintext in {@code {blog_post_title} ({blog_post_document_cms_url})}
+     * format.
+     *
+     * @param blogPost the {@link BlogPost} instance of the {@code hee:blogPost} document
+     *                 to which the comment has been submitted to.
+     * @param blogPostDocumentCMSURL the blog post document {@code hee:blogPost} CMS URL.
+     * @return the blog post document link for plaintext in {@code {blog_post_title} ({blog_post_document_cms_url})}
+     * format.
+     */
+    private String getBlogpostDocumentLinkForPlainText(final BlogPost blogPost, final String blogPostDocumentCMSURL) {
+        return blogPost.getTitle() + " (" + blogPostDocumentCMSURL + ")";
+    }
+
+    /**
+     * Returns blog post document link for HTML in {@code {blog_post_title} ({blog_post_document_cms_url})}
+     * format.
+     *
+     * @param blogPost the {@link BlogPost} instance of the {@code hee:blogPost} document
+     *                 to which the comment has been submitted to.
+     * @param blogPostDocumentCMSURL the blog post document {@code hee:blogPost} CMS URL.
+     * @return the blog post document link for HTML in {@code {blog_post_title} ({blog_post_document_cms_url})}
+     * format.
+     */
+    private String getBlogpostDocumentLinkForHTML(final BlogPost blogPost, final String blogPostDocumentCMSURL) {
+        return "<a href=\"" + blogPostDocumentCMSURL + "\">" + blogPost.getTitle() + "</a>";
+    }
+}

--- a/site/webapp/src/main/java/uk/nhs/hee/web/eform/behaviors/StoreBlogCommentBehavior.java
+++ b/site/webapp/src/main/java/uk/nhs/hee/web/eform/behaviors/StoreBlogCommentBehavior.java
@@ -3,6 +3,7 @@ package uk.nhs.hee.web.eform.behaviors;
 import com.google.common.base.Strings;
 import com.onehippo.cms7.eforms.hst.api.OnValidationSuccessBehavior;
 import com.onehippo.cms7.eforms.hst.beans.FormBean;
+import com.onehippo.cms7.eforms.hst.exceptions.EformBehaviorException;
 import com.onehippo.cms7.eforms.hst.model.Form;
 import org.hippoecm.hst.component.support.forms.FormField;
 import org.hippoecm.hst.component.support.forms.FormMap;
@@ -63,7 +64,10 @@ public class StoreBlogCommentBehavior implements OnValidationSuccessBehavior {
                 }
             }
         } catch (final Exception e) {
-            LOGGER.warn("Problem on handling blog comment posting: " + e.getMessage(), e);
+            final String errorMsg = "Caught error '" + e.getMessage() + "' while processing/storing the submitted blog post comment.";
+            LOGGER.error(errorMsg, e);
+            // Throwing 'EformBehaviorException' in order to fail the subsequent behaviours
+            throw new EformBehaviorException(errorMsg);
         }
     }
 
@@ -111,6 +115,7 @@ public class StoreBlogCommentBehavior implements OnValidationSuccessBehavior {
         final Map<String, FormField> formValues = map.getValue();
         commentNode.setProperty("hee:message", formValues.get("comment").getValue());
         commentNode.setProperty("hee:postedDate", Calendar.getInstance());
+        commentNode.setProperty("hee:moderated", Boolean.FALSE);
         final Node authorNode = commentNode.addNode("hee:author", "hee:blogCommentAuthor");
         authorNode.setProperty("hee:firstName", formValues.get("firstName").getValue());
         authorNode.setProperty("hee:lastName", formValues.get("lastName").getValue());


### PR DESCRIPTION
- `Moderated ?` field (`hee:moderated`) [defaulting to `false`] has been introduced on `hee:blogComment` CompoundType in order to record comment moderation status.
- `uk.nhs.hee.web.components.BlogPostComponent` has been updated to add only moderated comments to the model.
- `blog-comment-form` (catalog) component has been updated to use `uk.nhs.hee.web.components.eforms.NoAutoDetectFormComponent` from `com.onehippo.cms7.eforms.hst.components.AutoDetectFormComponent` in order to avoid auto detecting and adding default behaviours.
- An extension of `com.onehippo.cms7.eforms.hst.behaviors.MailFormDataBehavior` has been implemented `uk.nhs.hee.web.eforms.hst.behaviors.BlogPostCommentMailFormDataBehavior` for blog-comment-form to replace `##BLOG_POST_DOCUMENT##` placeholder with blog post (`hee:blogPost`) document CMS link to which the comment has been submitted to.
- `uk.nhs.hee.web.eform.behaviors.StoreBlogCommentBehavior` has been updated to throw `com.onehippo.cms7.eforms.hst.exceptions.EformBehaviorException` in case of error in order to fail the subsequent behaviours.
- Default `com.onehippo.cms7.eforms.hst.behaviors.StoreFormDataBehavior` has been removed from `blog-comment-form` component as we do not need to store them on JCR default location [`/formdata/permanent`] (as we already storing them on the corresponding blog post documents).
- Added `conf/context-dev.xml` (containing `'mail/Session' JavaMail connection factory JNDI resource`) and configured local instance (`cargo.run` profile) to use it (so that the packages/distributions for other env will continue using `conf/context.xml`). An example of how to configure/pass Java mail smtp properties is available in `pom.xml`:
```
File: pom.xml
450:                   <!-- Example to pass JavaMail connection factory JNDI resource attribute values as system properties -->
451:                   <!-- Alternatively these could directly be configured on 'conf/context-dev.xml'  -->
452:                   <!-- <mail.smtp.host><<mail.smtp.host>></mail.smtp.host></mail.smtp.host>
453:                   <mail.smtp.port><<mail.smtp.port>></mail.smtp.port>
454:                   <mail.smtp.user><<mail.smtp.user>></mail.smtp.user>
455:                   <mail.smtp.password><<mail.smtp.password>></mail.smtp.password>
456:                   <mail.smtp.auth><<mail.smtp.authv</mail.smtp.auth>
457:                   <mail.smtp.starttls.enable><<mail.smtp.starttls.enable>></mail.smtp.starttls.enable> -->
```
- The following updater scripts have been added for the indicated purposes:
  - `AddModerationStatusToBlogPostDocuments`: Adds moderation status i.e. `hee:moderated` property to existing comments of the blog post documents (`hee:blogPost`).
  - `UpdateBlogCommentFormContainerComponentsWithBlogPostModerationComponentConfig`: Updates `blog-comment-form` (container) component with blog post moderation component config (e.g. `hst:componentclassname`, `hst:parameternames`, etc)
- CICD pipeline setup to deploy distribution with `hee-smtp.properties` (containing mail SMTP properties) as Java system properties on all brCloud env.

**Manual steps:** The following manual steps needs to be executed post-release of the PR:
- Create a blog comment form separately for each channel with `Mail form data` behaviour enabled and configure `'To' e-mail address` field with the corresponding channel moderator email addresses.
- Execute the following updater scripts:
  - `AddModerationStatusToBlogPostDocuments`
  - `UpdateBlogCommentFormContainerComponentsWithBlogPostModerationComponentConfig`

Note that Editors should be advised to publish the blog post document after moderation so that the document will not be locked and so future comment submissions will be stored without any issues.

For information: Same `From` email name (`CMS Admin`) and address (`cms.admin@hee.nhs.uk`) has been configured for email moderation notification for all env to keep it simple for now.

Thanks!