### PR TITLE
NWPS-786: Support for multi-paragraph summary

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
@@ -50,7 +50,7 @@
 
                         <#--Blog Summary -->
                         <p class="nhsuk-body-l">
-                            ${document.summary!}
+                            <@hst.html formattedText="${document.summary?replace('\n', '<br>')}"/>
                         </p>
                         <#-- End Blog Summary -->
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/casestudylisting-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/casestudylisting-main.ftl
@@ -22,7 +22,9 @@
             <h1>
                 ${document.title}
             </h1>
-            <p class="nhsuk-lede-text">${document.summary}</p>
+            <p class="nhsuk-lede-text">
+                <@hst.html formattedText="${document.summary!?replace('\n', '<br>')}"/>
+            </p>
             <div class="nhsuk-listing">
                 <div class="nhsuk-grid-row">
                     <div class="nhsuk-grid-column-one-third">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/categorybasedlisting-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/categorybasedlisting-main.ftl
@@ -19,7 +19,9 @@
             <h1>
                 ${document.title}
             </h1>
-            <p class="nhsuk-lede-text">${document.summary}</p>
+            <p class="nhsuk-lede-text">
+                <@hst.html formattedText="${document.summary!?replace('\n', '<br>')}"/>
+            </p>
             <div class="nhsuk-listing">
                 <div class="nhsuk-grid-row">
                     <div class="nhsuk-grid-column-one-third">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/eventlisting-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/eventlisting-main.ftl
@@ -19,7 +19,9 @@
             <h1>
                 ${document.title}
             </h1>
-            <p class="nhsuk-lede-text">${document.summary}</p>
+            <p class="nhsuk-lede-text">
+                <@hst.html formattedText="${document.summary!?replace('\n', '<br>')}"/>
+            </p>
             <div class="nhsuk-listing">
                 <div class="nhsuk-grid-row">
                     <div class="nhsuk-grid-column-one-third">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/landingPage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/landingPage-main.ftl
@@ -8,7 +8,8 @@
             <h1>
                 ${document.title}
             </h1>
-            <p class="nhsuk-lede-text">${document.summary}</p>
+            <p class="nhsuk-lede-text">
+                <@hst.html formattedText="${document.summary!?replace('\n', '<br>')}"/>
             <div class="nhsuk-grid-row">
                 <div class="nhsuk-grid-column-full">
                     <@hee.contentCards contentCards=document.contentCards/>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/searchbanklisting-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/searchbanklisting-main.ftl
@@ -21,7 +21,9 @@
             <h1>
                 ${document.title}
             </h1>
-            <p class="nhsuk-lede-text">${document.summary}</p>
+            <p class="nhsuk-lede-text">
+                <@hst.html formattedText="${document.summary!?replace('\n', '<br>')}"/>
+            </p>
             <div class="nhsuk-listing">
                 <div class="nhsuk-grid-row">
                     <div class="nhsuk-grid-column-one-third">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/searchresults-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/searchresults-main.ftl
@@ -19,7 +19,9 @@
             <h1>
                 ${document.title}
             </h1>
-            <p class="nhsuk-lede-text">${document.summary}</p>
+            <p class="nhsuk-lede-text">
+                <@hst.html formattedText="${document.summary!?replace('\n', '<br>')}"/>
+            </p>
             <form method="get" action="">
                 <div class="nhsuk-form-group nhsuk-header__search-form--search-results">
                     <label class="nhsuk-label nhsuk-u-visually-hidden" for="search-field">Enter a search term</label>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
@@ -18,7 +18,9 @@
                     <div class="nhsuk-grid-column-two-thirds">
                         <section class="nhsuk-page-content__section-one">
                             <div class="nhsuk-page-content">
-                                <p>${guidanceDocument.summary}</p>
+                                <p class="nhsuk-body-l">
+                                    <@hst.html formattedText="${guidanceDocument.summary?replace('\n', '<br>')}"/>
+                                </p>
                                 <#if guidanceDocument.contentBlocks??>
                                     <#list guidanceDocument.contentBlocks as block>
                                         <#switch block.getClass().getName()>


### PR DESCRIPTION
Updated `blogPost`, `guidance`, `landing` and `listing` page freemarker templates to render summary line breaks with `<br>` tag to support multi-paragraph summary.