### PR TITLE
NWPS-805 & NWPS-815: Rewrite rule fixes

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/dental/hometodentaltraineerecruitment.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/dental/hometodentaltraineerecruitment.yaml
@@ -3,7 +3,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: de4aad88-5f72-4e90-8bb7-58d636fc58f9
   hippo:name: HomeToDentalTraineeRecruitment
-  hippo:versionHistory: ee6714ac-c970-45dd-9910-6f1efe950a6c
+  hippo:versionHistory: c47523ca-3388-49a7-aed6-97b81cb2f3f0
   /hometodentaltraineerecruitment[1]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable']
@@ -13,17 +13,17 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-12-23T12:44:13.900Z
-    hippostdpubwf:lastModificationDate: 2021-12-23T14:26:22.162Z
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:48:31.240Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2008-03-26T12:03:00+01:00
-    urlrewriter:rule: "<rule>\r\n<name>Home to Dental Trainee Recruitment for 'library.hee.nhs.uk'</name>\r\
-      \n<condition name=\"host\" operator=\"equal\">dental.hee.nhs.uk</condition>\r\
-      \n<from>^/$</from>\r\n<to type=\"permanent-redirect\" last=\"true\">/dental-trainee-recruitment</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n<name>Home to Dental Trainee Recruitment for hosts\
-      \ other than 'dental.hee.nhs.uk' host</name>\r\n<condition name=\"host\" operator=\"\
-      notequal\">dental.hee.nhs.uk</condition>\r\n<from>^/dental[/]?$</from>\r\n<to\
-      \ type=\"permanent-redirect\" last=\"true\">/site/dental/dental-trainee-recruitment</to>\r\
-      \n</rule>"
+    urlrewriter:rule: "<rule>\r\n    <name>Home to Dental Trainee Recruitment for\
+      \ 'dental.hee.nhs.uk'</name>\r\n    <condition name=\"host\" operator=\"equal\"\
+      >dental.hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\n    <to type=\"temporary-redirect\"\
+      \ last=\"true\">/dental-trainee-recruitment</to>\r\n</rule>\r\n\r\n<rule>\r\n\
+      \    <name>Home to Dental Trainee Recruitment for hosts other than 'hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
+      \n    <from>^/dental[/]?$</from>\r\n    <to type=\"temporary-redirect\" last=\"\
+      true\">/site/dental/dental-trainee-recruitment</to>\r\n</rule>"
   /hometodentaltraineerecruitment[2]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
@@ -33,16 +33,16 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-12-23T12:44:13.900Z
-    hippostdpubwf:lastModificationDate: 2021-12-23T14:26:34.805Z
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:48:51.226Z
     hippostdpubwf:lastModifiedBy: admin
-    urlrewriter:rule: "<rule>\r\n<name>Home to Dental Trainee Recruitment for 'library.hee.nhs.uk'</name>\r\
-      \n<condition name=\"host\" operator=\"equal\">dental.hee.nhs.uk</condition>\r\
-      \n<from>^/$</from>\r\n<to type=\"permanent-redirect\" last=\"true\">/dental-trainee-recruitment</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n<name>Home to Dental Trainee Recruitment for hosts\
-      \ other than 'dental.hee.nhs.uk' host</name>\r\n<condition name=\"host\" operator=\"\
-      notequal\">dental.hee.nhs.uk</condition>\r\n<from>^/dental[/]?$</from>\r\n<to\
-      \ type=\"permanent-redirect\" last=\"true\">/site/dental/dental-trainee-recruitment</to>\r\
-      \n</rule>"
+    urlrewriter:rule: "<rule>\r\n    <name>Home to Dental Trainee Recruitment for\
+      \ 'dental.hee.nhs.uk'</name>\r\n    <condition name=\"host\" operator=\"equal\"\
+      >dental.hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\n    <to type=\"temporary-redirect\"\
+      \ last=\"true\">/dental-trainee-recruitment</to>\r\n</rule>\r\n\r\n<rule>\r\n\
+      \    <name>Home to Dental Trainee Recruitment for hosts other than 'hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
+      \n    <from>^/dental[/]?$</from>\r\n    <to type=\"temporary-redirect\" last=\"\
+      true\">/site/dental/dental-trainee-recruitment</to>\r\n</rule>"
   /hometodentaltraineerecruitment[3]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable']
@@ -52,14 +52,14 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-12-23T12:44:13.900Z
-    hippostdpubwf:lastModificationDate: 2021-12-23T14:26:34.805Z
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:48:51.226Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2021-12-23T14:26:36.791Z
-    urlrewriter:rule: "<rule>\r\n<name>Home to Dental Trainee Recruitment for 'library.hee.nhs.uk'</name>\r\
-      \n<condition name=\"host\" operator=\"equal\">dental.hee.nhs.uk</condition>\r\
-      \n<from>^/$</from>\r\n<to type=\"permanent-redirect\" last=\"true\">/dental-trainee-recruitment</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n<name>Home to Dental Trainee Recruitment for hosts\
-      \ other than 'dental.hee.nhs.uk' host</name>\r\n<condition name=\"host\" operator=\"\
-      notequal\">dental.hee.nhs.uk</condition>\r\n<from>^/dental[/]?$</from>\r\n<to\
-      \ type=\"permanent-redirect\" last=\"true\">/site/dental/dental-trainee-recruitment</to>\r\
-      \n</rule>"
+    hippostdpubwf:publicationDate: 2022-01-05T11:49:45.196Z
+    urlrewriter:rule: "<rule>\r\n    <name>Home to Dental Trainee Recruitment for\
+      \ 'dental.hee.nhs.uk'</name>\r\n    <condition name=\"host\" operator=\"equal\"\
+      >dental.hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\n    <to type=\"temporary-redirect\"\
+      \ last=\"true\">/dental-trainee-recruitment</to>\r\n</rule>\r\n\r\n<rule>\r\n\
+      \    <name>Home to Dental Trainee Recruitment for hosts other than 'hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
+      \n    <from>^/dental[/]?$</from>\r\n    <to type=\"temporary-redirect\" last=\"\
+      true\">/site/dental/dental-trainee-recruitment</to>\r\n</rule>"

--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/dental/searchtosearchresultsredirect.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/dental/searchtosearchresultsredirect.yaml
@@ -3,7 +3,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: 0a56d231-101e-4530-8377-ee92d71c4e68
   hippo:name: SearchToSearchResultsRedirect
-  hippo:versionHistory: 1a4de8a3-f086-4e2a-b6d2-821f457158a4
+  hippo:versionHistory: e2be7673-aa8d-4ffc-b059-6e316e8e0a3d
   /searchtosearchresultsredirect[1]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable']
@@ -13,14 +13,14 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:06:55.832+01:00
-    hippostdpubwf:lastModificationDate: 2021-12-23T11:01:14.929Z
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:48:54.839Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2008-03-26T12:03:00+01:00
-    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for hosts other than 'dental.hee.nhs.uk'</name>\r\
-      \n    <condition name=\"host\" operator=\"equal\">dental.hee.nhs.uk</condition>\r\
+    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for 'dental.hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"equal\">dental.hee.nhs.uk</condition>\r\
       \n    <from>^/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\">/search/results?%{query-string}</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for 'dental.hee.nhs.uk'\
-      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">dental.hee.nhs.uk</condition>\r\
+      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for hosts other than 'hee.nhs.uk'</name>\r\
+      \n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
       \n    <from>^/dental/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\"\
       >/site/dental/search/results?%{query-string}</to>\r\n</rule>"
   /searchtosearchresultsredirect[2]:
@@ -32,13 +32,13 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:06:55.832+01:00
-    hippostdpubwf:lastModificationDate: 2021-12-23T11:01:25.255Z
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:49:39.324Z
     hippostdpubwf:lastModifiedBy: admin
-    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for hosts other than 'dental.hee.nhs.uk'</name>\r\
-      \n    <condition name=\"host\" operator=\"equal\">dental.hee.nhs.uk</condition>\r\
+    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for 'dental.hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"equal\">dental.hee.nhs.uk</condition>\r\
       \n    <from>^/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\">/search/results?%{query-string}</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for 'dental.hee.nhs.uk'\
-      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">dental.hee.nhs.uk</condition>\r\
+      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for hosts other than 'hee.nhs.uk'</name>\r\
+      \n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
       \n    <from>^/dental/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\"\
       >/site/dental/search/results?%{query-string}</to>\r\n</rule>"
   /searchtosearchresultsredirect[3]:
@@ -50,13 +50,13 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:06:55.832+01:00
-    hippostdpubwf:lastModificationDate: 2021-12-23T11:01:25.255Z
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:49:39.324Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2021-12-23T11:01:27.547Z
-    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for hosts other than 'dental.hee.nhs.uk'</name>\r\
-      \n    <condition name=\"host\" operator=\"equal\">dental.hee.nhs.uk</condition>\r\
+    hippostdpubwf:publicationDate: 2022-01-05T11:49:45.168Z
+    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for 'dental.hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"equal\">dental.hee.nhs.uk</condition>\r\
       \n    <from>^/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\">/search/results?%{query-string}</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for 'dental.hee.nhs.uk'\
-      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">dental.hee.nhs.uk</condition>\r\
+      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for hosts other than 'hee.nhs.uk'</name>\r\
+      \n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
       \n    <from>^/dental/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\"\
       >/site/dental/search/results?%{query-string}</to>\r\n</rule>"

--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls/hometoknowledgestaffredirect.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls/hometoknowledgestaffredirect.yaml
@@ -3,7 +3,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: d83669e2-039e-4239-96fa-2b39ac7ba539
   hippo:name: HomeToKnowledgeStaffRedirect
-  hippo:versionHistory: e9ab657b-09a9-46c6-ad17-b6a90ad516a4
+  hippo:versionHistory: fca6f207-fe65-4fb9-ac00-30e41ba021b6
   /hometoknowledgestaffredirect[1]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable']
@@ -13,17 +13,17 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:07:54.302+01:00
-    hippostdpubwf:lastModificationDate: 2021-05-25T15:08:26.297+01:00
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:50:23.382Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2008-03-26T12:03:00+01:00
-    urlrewriter:rule: "<rule>\r\n    <name>Home to Knowledge Staff Redirect for hosts\
-      \ other than 'library.hee.nhs.uk'</name>\r\n    <condition name=\"host\" operator=\"\
-      equal\">library.hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\n    <to type=\"\
-      permanent-redirect\" last=\"true\">/knowledge-staff</to>\r\n</rule>\r\n\r\n\
-      <rule>\r\n    <name>Home to Knowledge Staff Redirect for 'library.hee.nhs.uk'\
-      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
-      \n    <from>^/$</from>\r\n    <to type=\"permanent-redirect\" last=\"true\"\
-      >/site/knowledge-staff</to>\r\n</rule>"
+    urlrewriter:rule: "<rule>\r\n    <name>Home to Knowledge Staff Redirect for 'library.hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
+      \n    <from>^/$</from>\r\n    <to type=\"temporary-redirect\" last=\"true\"\
+      >/knowledge-staff</to>\r\n</rule>\r\n\r\n<rule>\r\n    <name>Home to Knowledge\
+      \ Staff Redirect for hosts other than 'hee.nhs.uk'</name>\r\n    <condition\
+      \ name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\
+      \n    <to type=\"temporary-redirect\" last=\"true\">/site/knowledge-staff</to>\r\
+      \n</rule>"
   /hometoknowledgestaffredirect[2]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
@@ -33,16 +33,16 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:07:54.302+01:00
-    hippostdpubwf:lastModificationDate: 2021-05-25T15:08:29.434+01:00
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:50:51.489Z
     hippostdpubwf:lastModifiedBy: admin
-    urlrewriter:rule: "<rule>\r\n    <name>Home to Knowledge Staff Redirect for hosts\
-      \ other than 'library.hee.nhs.uk'</name>\r\n    <condition name=\"host\" operator=\"\
-      equal\">library.hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\n    <to type=\"\
-      permanent-redirect\" last=\"true\">/knowledge-staff</to>\r\n</rule>\r\n\r\n\
-      <rule>\r\n    <name>Home to Knowledge Staff Redirect for 'library.hee.nhs.uk'\
-      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
-      \n    <from>^/$</from>\r\n    <to type=\"permanent-redirect\" last=\"true\"\
-      >/site/knowledge-staff</to>\r\n</rule>"
+    urlrewriter:rule: "<rule>\r\n    <name>Home to Knowledge Staff Redirect for 'library.hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
+      \n    <from>^/$</from>\r\n    <to type=\"temporary-redirect\" last=\"true\"\
+      >/knowledge-staff</to>\r\n</rule>\r\n\r\n<rule>\r\n    <name>Home to Knowledge\
+      \ Staff Redirect for hosts other than 'hee.nhs.uk'</name>\r\n    <condition\
+      \ name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\
+      \n    <to type=\"temporary-redirect\" last=\"true\">/site/knowledge-staff</to>\r\
+      \n</rule>"
   /hometoknowledgestaffredirect[3]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable']
@@ -52,14 +52,14 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:07:54.302+01:00
-    hippostdpubwf:lastModificationDate: 2021-05-25T15:08:29.434+01:00
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:50:51.489Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2021-05-25T15:08:31.158+01:00
-    urlrewriter:rule: "<rule>\r\n    <name>Home to Knowledge Staff Redirect for hosts\
-      \ other than 'library.hee.nhs.uk'</name>\r\n    <condition name=\"host\" operator=\"\
-      equal\">library.hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\n    <to type=\"\
-      permanent-redirect\" last=\"true\">/knowledge-staff</to>\r\n</rule>\r\n\r\n\
-      <rule>\r\n    <name>Home to Knowledge Staff Redirect for 'library.hee.nhs.uk'\
-      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
-      \n    <from>^/$</from>\r\n    <to type=\"permanent-redirect\" last=\"true\"\
-      >/site/knowledge-staff</to>\r\n</rule>"
+    hippostdpubwf:publicationDate: 2022-01-05T11:50:53.415Z
+    urlrewriter:rule: "<rule>\r\n    <name>Home to Knowledge Staff Redirect for 'library.hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
+      \n    <from>^/$</from>\r\n    <to type=\"temporary-redirect\" last=\"true\"\
+      >/knowledge-staff</to>\r\n</rule>\r\n\r\n<rule>\r\n    <name>Home to Knowledge\
+      \ Staff Redirect for hosts other than 'hee.nhs.uk'</name>\r\n    <condition\
+      \ name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\n    <from>^/$</from>\r\
+      \n    <to type=\"temporary-redirect\" last=\"true\">/site/knowledge-staff</to>\r\
+      \n</rule>"

--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls/kfhtolksredirects.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls/kfhtolksredirects.yaml
@@ -4,7 +4,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: 3e5c8fac-e733-40e0-8151-f78e9d2253de
   hippo:name: KFHToLKSRedirects
-  hippo:versionHistory: b00ff53a-2848-448c-8eb2-4f6f50e93920
+  hippo:versionHistory: 70bdd253-321f-4060-9e82-df71879999dc
   /kfhtolksredirects[1]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:versionable']
@@ -14,7 +14,7 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:07:54.302+01:00
-    hippostdpubwf:lastModificationDate: 2021-07-01T10:19:53.417+01:00
+    hippostdpubwf:lastModificationDate: 2022-01-05T09:48:21.076Z
     hippostdpubwf:lastModifiedBy: admin
     urlrewriter:rule: "<rule>\r\n  <name>kfh.libraryservices.nhs.uk to library.hee.nhs.uk\
       \ Domain Level Redirect</name>\r\n  <note>This redirect added here intentionally\
@@ -486,10 +486,6 @@
       \n</rule>\r\n<rule>\r\n  <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
       \n  <from>^/covid-19-coronavirus/evidence-sources/?$</from>\r\n  <to type=\"\
       permanent-redirect\" last=\"true\">/site/covid-19/coronavirus-evidence-sources</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
-      \n  <from>^/?$</from>\r\n  <to type=\"permanent-redirect\" last=\"true\">/knowledge-staff</to>\r\
-      \n</rule>\r\n<rule>\r\n  <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
-      \n  <from>^/?$</from>\r\n  <to type=\"permanent-redirect\" last=\"true\">/site/knowledge-staff</to>\r\
       \n</rule>\r\n\r\n<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
       \n  <from>^/covid-19-coronavirus/for-lks-staff/literature-searches/?$</from>\r\
       \n  <to type=\"permanent-redirect\" last=\"true\">/covid-19/covid-19-search-bank</to>\r\
@@ -1690,7 +1686,7 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:07:54.302+01:00
-    hippostdpubwf:lastModificationDate: 2021-07-01T10:19:46.754+01:00
+    hippostdpubwf:lastModificationDate: 2022-01-05T09:48:03.417Z
     hippostdpubwf:lastModifiedBy: admin
     urlrewriter:rule: "<rule>\r\n  <name>kfh.libraryservices.nhs.uk to library.hee.nhs.uk\
       \ Domain Level Redirect</name>\r\n  <note>This redirect added here intentionally\
@@ -2162,10 +2158,6 @@
       \n</rule>\r\n<rule>\r\n  <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
       \n  <from>^/covid-19-coronavirus/evidence-sources/?$</from>\r\n  <to type=\"\
       permanent-redirect\" last=\"true\">/site/covid-19/coronavirus-evidence-sources</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
-      \n  <from>^/?$</from>\r\n  <to type=\"permanent-redirect\" last=\"true\">/knowledge-staff</to>\r\
-      \n</rule>\r\n<rule>\r\n  <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
-      \n  <from>^/?$</from>\r\n  <to type=\"permanent-redirect\" last=\"true\">/site/knowledge-staff</to>\r\
       \n</rule>\r\n\r\n<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
       \n  <from>^/covid-19-coronavirus/for-lks-staff/literature-searches/?$</from>\r\
       \n  <to type=\"permanent-redirect\" last=\"true\">/covid-19/covid-19-search-bank</to>\r\
@@ -3366,9 +3358,9 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:07:54.302+01:00
-    hippostdpubwf:lastModificationDate: 2021-07-01T10:19:53.417+01:00
+    hippostdpubwf:lastModificationDate: 2022-01-05T09:48:21.076Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2021-07-01T10:19:55.845+01:00
+    hippostdpubwf:publicationDate: 2022-01-05T09:48:24.454Z
     urlrewriter:rule: "<rule>\r\n  <name>kfh.libraryservices.nhs.uk to library.hee.nhs.uk\
       \ Domain Level Redirect</name>\r\n  <note>This redirect added here intentionally\
       \ in order to ensure that the domain level redirect happens first before any\
@@ -3839,10 +3831,6 @@
       \n</rule>\r\n<rule>\r\n  <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
       \n  <from>^/covid-19-coronavirus/evidence-sources/?$</from>\r\n  <to type=\"\
       permanent-redirect\" last=\"true\">/site/covid-19/coronavirus-evidence-sources</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
-      \n  <from>^/?$</from>\r\n  <to type=\"permanent-redirect\" last=\"true\">/knowledge-staff</to>\r\
-      \n</rule>\r\n<rule>\r\n  <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
-      \n  <from>^/?$</from>\r\n  <to type=\"permanent-redirect\" last=\"true\">/site/knowledge-staff</to>\r\
       \n</rule>\r\n\r\n<rule>\r\n  <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
       \n  <from>^/covid-19-coronavirus/for-lks-staff/literature-searches/?$</from>\r\
       \n  <to type=\"permanent-redirect\" last=\"true\">/covid-19/covid-19-search-bank</to>\r\

--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls/searchtosearchresultsredirect.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls/searchtosearchresultsredirect.yaml
@@ -4,7 +4,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: 695b8033-6dc4-441e-aae2-58d85d4dcb0e
   hippo:name: SearchToSearchResultsRedirect
-  hippo:versionHistory: 109d827b-761f-4eaf-9f72-edf143bddf6f
+  hippo:versionHistory: da5ea135-ea63-49e9-b24b-6adee50fa4ce
   /searchtosearchresultsredirect[1]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable']
@@ -14,14 +14,14 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:06:55.832+01:00
-    hippostdpubwf:lastModificationDate: 2021-06-23T14:28:34.259+01:00
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:49:56.137Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2008-03-26T12:03:00+01:00
-    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for hosts other than 'library.hee.nhs.uk'</name>\r\
-      \n    <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
+    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for 'library.hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
       \n    <from>^/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\">/search/results?%{query-string}</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for 'library.hee.nhs.uk'\
-      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
+      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for hosts other than 'hee.nhs.uk'</name>\r\
+      \n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
       \n    <from>^/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\">/site/search/results?%{query-string}</to>\r\
       \n</rule>"
   /searchtosearchresultsredirect[2]:
@@ -33,13 +33,13 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:06:55.832+01:00
-    hippostdpubwf:lastModificationDate: 2021-06-23T14:28:40.390+01:00
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:50:21.208Z
     hippostdpubwf:lastModifiedBy: admin
-    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for hosts other than 'library.hee.nhs.uk'</name>\r\
-      \n    <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
+    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for 'library.hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
       \n    <from>^/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\">/search/results?%{query-string}</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for 'library.hee.nhs.uk'\
-      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
+      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for hosts other than 'hee.nhs.uk'</name>\r\
+      \n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
       \n    <from>^/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\">/site/search/results?%{query-string}</to>\r\
       \n</rule>"
   /searchtosearchresultsredirect[3]:
@@ -51,13 +51,13 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-05-25T15:06:55.832+01:00
-    hippostdpubwf:lastModificationDate: 2021-06-23T14:28:40.390+01:00
+    hippostdpubwf:lastModificationDate: 2022-01-05T11:50:21.208Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2021-06-23T14:28:42.131+01:00
-    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for hosts other than 'library.hee.nhs.uk'</name>\r\
-      \n    <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
+    hippostdpubwf:publicationDate: 2022-01-05T11:50:56.764Z
+    urlrewriter:rule: "<rule>\r\n    <name>Search Redirect for 'library.hee.nhs.uk'\
+      \ host</name>\r\n    <condition name=\"host\" operator=\"equal\">library.hee.nhs.uk</condition>\r\
       \n    <from>^/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\">/search/results?%{query-string}</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for 'library.hee.nhs.uk'\
-      \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">library.hee.nhs.uk</condition>\r\
+      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for hosts other than 'hee.nhs.uk'</name>\r\
+      \n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
       \n    <from>^/search/?$</from>\r\n    <to type=\"redirect\" last=\"true\">/site/search/results?%{query-string}</to>\r\
       \n</rule>"


### PR DESCRIPTION
- Removal of `knowledge-staff` redirects from 'KFHToLKSRedirects' rewrite rule.
- Simplifying and optimising KLS and dental channel home & search rewrite rules for internal & external redirects.
- Converting KLS and dental channel home redirects from `301` (permanent) to `302` (temporary).

*Note* that the rewrite rule fixes included in this PR has already been applied to prod and the PR is essentially to keep the repository in sync. Thanks!