### PR TITLE
Add details document type and details (reusable) compound type.

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-details-document.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-details-document.yaml
@@ -1,0 +1,10 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:queries/hippo:templates/new-details-document:
+      jcr:primaryType: hippostd:templatequery
+      hippostd:modify: [./_name, $name, './hippotranslation:locale', $inherited, './hippotranslation:id',
+        $uuid, './hippostdpubwf:createdBy', $holder, './hippostdpubwf:creationDate',
+        $now, './hippostdpubwf:lastModifiedBy', $holder, './hippostdpubwf:lastModificationDate',
+        $now, './hippostd:holder', $holder]
+      jcr:language: xpath
+      jcr:statement: //element(*,hipposysedit:namespacefolder)/element(*,mix:referenceable)/element(*,hipposysedit:templatetype)/hipposysedit:prototypes/element(hipposysedit:prototype,hee:details)

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/templates.yaml
@@ -49,6 +49,7 @@ definitions:
       new-logo-document: new logo document
       new-logoGroup-document: new logo group document
       new-logoGroup-folder: new logo group folder
+      new-details-document: new details document
     /hippo:configuration/hippo:translations/hippo:templates/fr:
       new-resource-bundle: nouveau resource bundle
       new-untranslated-folder: nouveau dossier non traduit

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
@@ -262,3 +262,13 @@ definitions:
       /en:
         jcr:primaryType: hipposys:resourcebundle
         jcr:name: Logo group
+    /hippo:configuration/hippo:translations/hippo:types/hee:details:
+      jcr:primaryType: hipposys:resourcebundles
+      /en:
+        jcr:primaryType: hipposys:resourcebundle
+        jcr:name: Details
+    /hippo:configuration/hippo:translations/hippo:types/hee:detailsReference:
+      jcr:primaryType: hipposys:resourcebundles
+      /en:
+        jcr:primaryType: hipposys:resourcebundle
+        jcr:name: Details (reusable)

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee-cms-platform.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee-cms-platform.cnd
@@ -86,6 +86,12 @@
 [hee:department] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
   orderable
 
+[hee:details] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
+  orderable
+
+[hee:detailsReference] > hippo:compound, hippostd:relaxed
+  orderable
+
 [hee:event] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
   orderable
 

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/HomePage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/HomePage.yaml
@@ -134,7 +134,7 @@ definitions:
           /contentBlocks:
             jcr:primaryType: frontend:plugin
             caption: Main content objects
-            compoundList: hee:ActionLink,hee:anchorLinks,hee:blockLinksReference,hee:contact,hee:contentCards,hippostd:html,hippogallerypicker:imagelink,hee:mediaEmbedReference,hee:navMap,hee:richTextReference,hee:StatementBlock,hee:tabsReference,hee:YellowAlertBlock
+            compoundList: hee:ActionLink,hee:anchorLinks,hee:blockLinksReference,hee:contact,hee:contentCards,hee:detailsReference,hippostd:html,hippogallerypicker:imagelink,hee:mediaEmbedReference,hee:navMap,hee:richTextReference,hee:StatementBlock,hee:tabsReference,hee:YellowAlertBlock
             contentPickerType: links
             field: contentBlocks
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/details.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/details.yaml
@@ -1,0 +1,81 @@
+definitions:
+  config:
+    /hippo:namespaces/hee/details:
+      jcr:primaryType: hipposysedit:templatetype
+      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      jcr:uuid: 3962c42f-60bc-4da6-b95f-0f2475da27ed
+      /hipposysedit:nodetype:
+        jcr:primaryType: hippo:handle
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: 3ee07009-f9fa-4930-a45b-dc9fab99335d
+        /hipposysedit:nodetype:
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
+          jcr:uuid: ff23f258-bb03-4297-b57b-fcaab2b733b5
+          hipposysedit:node: true
+          hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
+          hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
+          /summary:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:summary
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators: [required]
+          /content:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:richStatement
+            hipposysedit:primary: false
+            hipposysedit:type: hippostd:html
+            hipposysedit:validators: [required]
+      /hipposysedit:prototypes:
+        jcr:primaryType: hipposysedit:prototypeset
+        /hipposysedit:prototype:
+          jcr:primaryType: hee:details
+          hippostd:holder: holder
+          hippostd:state: draft
+          hippostdpubwf:createdBy: ''
+          hippostdpubwf:lastModifiedBy: ''
+          hippotranslation:id: document-type-locale-id
+          hippotranslation:locale: document-type-locale
+          jcr:mixinTypes: ['mix:referenceable']
+          hee:summary: ''
+          jcr:uuid: 7cb9362a-21d5-48ad-94c0-4b96b0df82a4
+          hippostdpubwf:lastModificationDate: 2022-01-17T21:00:21.639Z
+          hippostdpubwf:creationDate: 2022-01-17T21:00:21.639Z
+          /hee:richStatement:
+            jcr:primaryType: hippostd:html
+            hippostd:content: ''
+      /editor:templates:
+        jcr:primaryType: editor:templateset
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties: [mode]
+          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
+          frontend:services: [wicket.id, validator.id]
+          /root:
+            jcr:primaryType: frontend:plugin
+            item: ${cluster.id}.field
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /summary:
+            jcr:primaryType: frontend:plugin
+            caption: Summary
+            field: summary
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+            hint: ''
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+          /richStatement:
+            jcr:primaryType: frontend:plugin
+            caption: Content
+            field: content
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/detailsReference.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/detailsReference.yaml
@@ -1,0 +1,53 @@
+definitions:
+  config:
+    /hippo:namespaces/hee/detailsReference:
+      jcr:primaryType: hipposysedit:templatetype
+      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      jcr:uuid: a592c3de-534f-45be-835c-d8f9147f38f0
+      /hipposysedit:nodetype:
+        jcr:primaryType: hippo:handle
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: f4068a8f-9979-4191-bae5-74d4a2e67335
+        /hipposysedit:nodetype:
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
+          jcr:uuid: 387d46d6-ef30-4105-bb92-233689a77d1e
+          hipposysedit:node: true
+          hipposysedit:supertype: ['hippo:compound', 'hippostd:relaxed']
+          hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
+          /content:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:detailsContentBlock
+            hipposysedit:primary: false
+            hipposysedit:type: hippo:mirror
+            hipposysedit:validators: [required]
+      /hipposysedit:prototypes:
+        jcr:primaryType: hipposysedit:prototypeset
+        /hipposysedit:prototype:
+          jcr:primaryType: hee:detailsReference
+          /hee:detailsContentBlock:
+            jcr:primaryType: hippo:mirror
+            hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+      /editor:templates:
+        jcr:primaryType: editor:templateset
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties: [mode]
+          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
+          frontend:services: [wicket.id, validator.id]
+          /root:
+            jcr:primaryType: frontend:plugin
+            item: ${cluster.id}.field
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /detailsContentBlock:
+            jcr:primaryType: frontend:plugin
+            caption: Select details
+            field: content
+            hint: ''
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
@@ -182,7 +182,7 @@ definitions:
           /contentBlocks:
             jcr:primaryType: frontend:plugin
             caption: Main content objects
-            compoundList: hee:ActionLink,hee:anchorLinks,hee:blockLinksReference,hee:contact,hee:contentCards,hippostd:html,hippogallerypicker:imagelink,hee:mediaEmbedReference,hee:richTextReference,hee:StatementBlock,hee:tabsReference,hee:YellowAlertBlock
+            compoundList: hee:ActionLink,hee:anchorLinks,hee:blockLinksReference,hee:contact,hee:contentCards,hee:detailsReference,hippostd:html,hippogallerypicker:imagelink,hee:mediaEmbedReference,hee:richTextReference,hee:StatementBlock,hee:tabsReference,hee:YellowAlertBlock
             contentPickerType: links
             field: contentBlocks
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin

--- a/repository-data/development/src/main/resources/hcm-actions.yaml
+++ b/repository-data/development/src/main/resources/hcm-actions.yaml
@@ -73,3 +73,7 @@ action-lists:
       /content/documents/lks/minihubs: reload
   - 1.0.36:
       /content/documents/lks/listing-pages: reload
+  - 1.0.37:
+      /content/documents/lks/guidance-pages: reload
+      /content/documents/lks/home: reload
+      /content/documents/lks/blogposts: reload

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
@@ -4238,3 +4238,105 @@
         /hee:logos[2]:
           jcr:primaryType: hippo:mirror
           hippo:docbase: ce765353-3e19-473a-893c-446aa09ae955
+  /details:
+    jcr:primaryType: hippostd:folder
+    jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
+    jcr:uuid: 778c475c-9bab-4dc0-a50e-a2d84cb41ff9
+    hippo:name: Details
+    hippostd:foldertype: [new-details-document]
+    hippotranslation:id: b03cd624-9cf9-4415-88a0-7ab45ac1f8f1
+    hippotranslation:locale: en
+    /demodetails:
+      jcr:primaryType: hippo:handle
+      jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
+      jcr:uuid: fdf33d93-cb1f-4a12-a954-c5f187e767d2
+      hippo:name: DemoDetails
+      hippo:versionHistory: 993fefcb-e718-4901-8ca6-445f6149ead7
+      /demodetails[1]:
+        jcr:primaryType: hee:details
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: d46445c6-b245-4676-aaf0-f7dc98b9b445
+        hee:summary: How to find your NHS number
+        hippo:availability: []
+        hippostd:retainable: false
+        hippostd:state: draft
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2022-01-18T09:47:21.148Z
+        hippostdpubwf:lastModificationDate: 2022-01-18T09:49:52.654Z
+        hippostdpubwf:lastModifiedBy: admin
+        hippotranslation:id: 64fabb6b-7848-48bd-8062-c76f72946310
+        hippotranslation:locale: en
+        /hee:richStatement:
+          jcr:primaryType: hippostd:html
+          hippostd:content: |-
+            <p>An NHS number is a 10 digit number, like 485 777 3456.</p>
+
+            <p>You can find your NHS number by logging in to a GP online service or on any document the NHS has sent you, such as your:</p>
+
+            <ul>
+             <li>prescriptions</li>
+             <li>test results</li>
+             <li>hospital referral letters</li>
+             <li>appointment letters</li>
+            </ul>
+
+            <p>Ask your GP surgery for help if you can't find your NHS number.</p>
+      /demodetails[2]:
+        jcr:primaryType: hee:details
+        jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+        jcr:uuid: bf964ac2-10f0-467f-afda-e34e11bfbdb4
+        hee:summary: How to find your NHS number
+        hippo:availability: [preview]
+        hippostd:retainable: false
+        hippostd:state: unpublished
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2022-01-18T09:47:21.148Z
+        hippostdpubwf:lastModificationDate: 2022-01-18T09:49:52.624Z
+        hippostdpubwf:lastModifiedBy: admin
+        hippotranslation:id: 64fabb6b-7848-48bd-8062-c76f72946310
+        hippotranslation:locale: en
+        /hee:richStatement:
+          jcr:primaryType: hippostd:html
+          hippostd:content: |-
+            <p>An NHS number is a 10 digit number, like 485 777 3456.</p>
+
+            <p>You can find your NHS number by logging in to a GP online service or on any document the NHS has sent you, such as your:</p>
+
+            <ul>
+             <li>prescriptions</li>
+             <li>test results</li>
+             <li>hospital referral letters</li>
+             <li>appointment letters</li>
+            </ul>
+
+            <p>Ask your GP surgery for help if you can't find your NHS number.</p>
+      /demodetails[3]:
+        jcr:primaryType: hee:details
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: 4e723325-f15b-408d-997a-3476114b2d07
+        hee:summary: How to find your NHS number
+        hippo:availability: [live]
+        hippostd:retainable: false
+        hippostd:state: published
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2022-01-18T09:47:21.148Z
+        hippostdpubwf:lastModificationDate: 2022-01-18T09:49:52.624Z
+        hippostdpubwf:lastModifiedBy: admin
+        hippostdpubwf:publicationDate: 2022-01-18T09:49:56.170Z
+        hippotranslation:id: 64fabb6b-7848-48bd-8062-c76f72946310
+        hippotranslation:locale: en
+        /hee:richStatement:
+          jcr:primaryType: hippostd:html
+          hippostd:content: |-
+            <p>An NHS number is a 10 digit number, like 485 777 3456.</p>
+
+            <p>You can find your NHS number by logging in to a GP online service or on any document the NHS has sent you, such as your:</p>
+
+            <ul>
+             <li>prescriptions</li>
+             <li>test results</li>
+             <li>hospital referral letters</li>
+             <li>appointment letters</li>
+            </ul>
+
+            <p>Ask your GP surgery for help if you can't find your NHS number.</p>

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/guidance-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/guidance-pages.yaml
@@ -12,7 +12,7 @@
     jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
     jcr:uuid: 9071bfc1-35e4-4cb8-852c-c91f97fb43f0
     hippo:name: Copyright
-    hippo:versionHistory: 1d6d5a3a-c4cf-4df2-9190-ca2646ec562d
+    hippo:versionHistory: 48f4e1b5-9005-427e-9d6c-352cb377f1af
     /copyright[1]:
       jcr:primaryType: hee:guidance
       jcr:mixinTypes: ['mix:versionable']
@@ -25,7 +25,7 @@
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-03T15:52:21.360+07:00
-      hippostdpubwf:lastModificationDate: 2021-12-17T16:29:03.600Z
+      hippostdpubwf:lastModificationDate: 2022-01-18T09:48:43.138Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 203579fe-0110-4d7e-a784-29206ca94a04
       hippotranslation:locale: en
@@ -142,6 +142,7 @@
         jcr:primaryType: hee:ActionLink
         /hee:link:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Internal Link
           hee:url: ''
           hippostdpubwf:createdBy: ''
@@ -157,6 +158,7 @@
         jcr:primaryType: hee:ActionLink
         /hee:link:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: External Link
           hee:url: https://service-manual.nhs.uk/design-system/components/action-link
           hippostdpubwf:createdBy: ''
@@ -172,6 +174,7 @@
         jcr:primaryType: hee:ActionLink
         /hee:link:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: An other internal link
           hee:url: ''
           hippostdpubwf:createdBy: ''
@@ -198,6 +201,7 @@
         hee:title: Related posts
         /hee:links[1]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Expert searching
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -211,6 +215,7 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[2]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Search bank
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -224,6 +229,7 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[3]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Costing
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -237,6 +243,7 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[4]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Search training
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -253,6 +260,7 @@
         hee:title: Second Quick Links
         /hee:links:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Search bank
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -356,6 +364,11 @@
       /hee:logoGroup:
         jcr:primaryType: hippo:mirror
         hippo:docbase: 40556fdc-a879-446a-ba43-11556315c17a
+      /hee:contentBlocks[15]:
+        jcr:primaryType: hee:detailsReference
+        /hee:detailsContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: fdf33d93-cb1f-4a12-a954-c5f187e767d2
     /copyright[2]:
       jcr:primaryType: hee:guidance
       jcr:mixinTypes: ['mix:referenceable']
@@ -368,7 +381,7 @@
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-03T15:52:21.360+07:00
-      hippostdpubwf:lastModificationDate: 2021-12-17T16:28:50.189Z
+      hippostdpubwf:lastModificationDate: 2022-01-18T09:48:43.330Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 203579fe-0110-4d7e-a784-29206ca94a04
       hippotranslation:locale: en
@@ -485,6 +498,7 @@
         jcr:primaryType: hee:ActionLink
         /hee:link:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Internal Link
           hee:url: ''
           hippostdpubwf:createdBy: ''
@@ -500,6 +514,7 @@
         jcr:primaryType: hee:ActionLink
         /hee:link:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: External Link
           hee:url: https://service-manual.nhs.uk/design-system/components/action-link
           hippostdpubwf:createdBy: ''
@@ -515,6 +530,7 @@
         jcr:primaryType: hee:ActionLink
         /hee:link:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: An other internal link
           hee:url: ''
           hippostdpubwf:createdBy: ''
@@ -541,6 +557,7 @@
         hee:title: Related posts
         /hee:links[1]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Expert searching
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -554,6 +571,7 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[2]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Search bank
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -567,6 +585,7 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[3]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Costing
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -580,6 +599,7 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[4]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Search training
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -596,6 +616,7 @@
         hee:title: Second Quick Links
         /hee:links:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Search bank
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -699,6 +720,11 @@
       /hee:logoGroup:
         jcr:primaryType: hippo:mirror
         hippo:docbase: 40556fdc-a879-446a-ba43-11556315c17a
+      /hee:contentBlocks[15]:
+        jcr:primaryType: hee:detailsReference
+        /hee:detailsContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: fdf33d93-cb1f-4a12-a954-c5f187e767d2
     /copyright[3]:
       jcr:primaryType: hee:guidance
       jcr:mixinTypes: ['mix:referenceable']
@@ -711,9 +737,9 @@
       hippostd:state: published
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-03T15:52:21.360+07:00
-      hippostdpubwf:lastModificationDate: 2021-12-17T16:29:03.600Z
+      hippostdpubwf:lastModificationDate: 2022-01-18T09:48:43.138Z
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2021-12-17T16:29:07.522Z
+      hippostdpubwf:publicationDate: 2022-01-18T09:48:48.972Z
       hippotranslation:id: 203579fe-0110-4d7e-a784-29206ca94a04
       hippotranslation:locale: en
       /hee:contentBlocks[1]:
@@ -829,6 +855,7 @@
         jcr:primaryType: hee:ActionLink
         /hee:link:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Internal Link
           hee:url: ''
           hippostdpubwf:createdBy: ''
@@ -844,6 +871,7 @@
         jcr:primaryType: hee:ActionLink
         /hee:link:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: External Link
           hee:url: https://service-manual.nhs.uk/design-system/components/action-link
           hippostdpubwf:createdBy: ''
@@ -859,6 +887,7 @@
         jcr:primaryType: hee:ActionLink
         /hee:link:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: An other internal link
           hee:url: ''
           hippostdpubwf:createdBy: ''
@@ -885,6 +914,7 @@
         hee:title: Related posts
         /hee:links[1]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Expert searching
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -898,6 +928,7 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[2]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Search bank
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -911,6 +942,7 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[3]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Costing
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -924,6 +956,7 @@
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         /hee:links[4]:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Search training
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -940,6 +973,7 @@
         hee:title: Second Quick Links
         /hee:links:
           jcr:primaryType: hee:link
+          hee:openLinkUrlNewWindow: false
           hee:text: Search bank
           hee:url: /
           hippostdpubwf:createdBy: ''
@@ -1043,6 +1077,11 @@
       /hee:logoGroup:
         jcr:primaryType: hippo:mirror
         hippo:docbase: 40556fdc-a879-446a-ba43-11556315c17a
+      /hee:contentBlocks[15]:
+        jcr:primaryType: hee:detailsReference
+        /hee:detailsContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: fdf33d93-cb1f-4a12-a954-c5f187e767d2
   /introduction:
     jcr:primaryType: hippo:handle
     jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/home.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/home.yaml
@@ -4,7 +4,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: ef78c935-2f90-48d2-919f-5f99073f1832
   hippo:name: Home
-  hippo:versionHistory: 3ecb1d25-6174-4fa1-bba4-286b45564396
+  hippo:versionHistory: 3869c3c5-cd2f-4933-a109-6b8fea9ce5f6
   /home[1]:
     jcr:primaryType: hee:HomePage
     jcr:mixinTypes: ['mix:referenceable']
@@ -14,9 +14,10 @@
     hippo:availability: []
     hippostd:retainable: false
     hippostd:state: draft
+    hippostd:transferable: false
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-03-24T17:00:56.449+07:00
-    hippostdpubwf:lastModificationDate: 2021-11-14T23:19:13.404Z
+    hippostdpubwf:lastModificationDate: 2022-01-18T10:10:14.951Z
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 104788bb-9ba3-4f82-87d8-2157f09cbf6c
     hippotranslation:locale: en
@@ -485,11 +486,16 @@
         jcr:primaryType: hippo:mirror
         hippo:docbase: d53bd083-c132-4db4-888c-dacf5314b9af
     /hee:contentBlocks[11]:
+      jcr:primaryType: hee:detailsReference
+      /hee:detailsContentBlock:
+        jcr:primaryType: hippo:mirror
+        hippo:docbase: fdf33d93-cb1f-4a12-a954-c5f187e767d2
+    /hee:contentBlocks[12]:
       jcr:primaryType: hee:mediaEmbedReference
       /hee:mediaEmbedContentBlock:
         jcr:primaryType: hippo:mirror
         hippo:docbase: 02090386-3700-441e-8e27-e3e67780fc1a
-    /hee:contentBlocks[12]:
+    /hee:contentBlocks[13]:
       jcr:primaryType: hee:contentCards
       hee:cardGroupSummary: "Eros tristique tincidunt massa consectetur aliquam mi\
         \ tempus maximus ac suspendisse erat nisi rutrum mi orci phasellus euismod\
@@ -517,7 +523,7 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-03-24T17:00:56.449+07:00
-    hippostdpubwf:lastModificationDate: 2021-11-14T23:20:30.555Z
+    hippostdpubwf:lastModificationDate: 2022-01-18T10:09:37.155Z
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 104788bb-9ba3-4f82-87d8-2157f09cbf6c
     hippotranslation:locale: en
@@ -986,11 +992,16 @@
         jcr:primaryType: hippo:mirror
         hippo:docbase: d53bd083-c132-4db4-888c-dacf5314b9af
     /hee:contentBlocks[11]:
+      jcr:primaryType: hee:detailsReference
+      /hee:detailsContentBlock:
+        jcr:primaryType: hippo:mirror
+        hippo:docbase: fdf33d93-cb1f-4a12-a954-c5f187e767d2
+    /hee:contentBlocks[12]:
       jcr:primaryType: hee:mediaEmbedReference
       /hee:mediaEmbedContentBlock:
         jcr:primaryType: hippo:mirror
         hippo:docbase: 02090386-3700-441e-8e27-e3e67780fc1a
-    /hee:contentBlocks[12]:
+    /hee:contentBlocks[13]:
       jcr:primaryType: hee:contentCards
       hee:cardGroupSummary: "Eros tristique tincidunt massa consectetur aliquam mi\
         \ tempus maximus ac suspendisse erat nisi rutrum mi orci phasellus euismod\
@@ -1018,9 +1029,9 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-03-24T17:00:56.449+07:00
-    hippostdpubwf:lastModificationDate: 2021-11-14T23:20:30.555Z
+    hippostdpubwf:lastModificationDate: 2022-01-18T10:09:37.155Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2021-11-14T23:20:35.669Z
+    hippostdpubwf:publicationDate: 2022-01-18T10:09:41.160Z
     hippotranslation:id: 104788bb-9ba3-4f82-87d8-2157f09cbf6c
     hippotranslation:locale: en
     /hee:contentBlocks[1]:
@@ -1488,11 +1499,16 @@
         jcr:primaryType: hippo:mirror
         hippo:docbase: d53bd083-c132-4db4-888c-dacf5314b9af
     /hee:contentBlocks[11]:
+      jcr:primaryType: hee:detailsReference
+      /hee:detailsContentBlock:
+        jcr:primaryType: hippo:mirror
+        hippo:docbase: fdf33d93-cb1f-4a12-a954-c5f187e767d2
+    /hee:contentBlocks[12]:
       jcr:primaryType: hee:mediaEmbedReference
       /hee:mediaEmbedContentBlock:
         jcr:primaryType: hippo:mirror
         hippo:docbase: 02090386-3700-441e-8e27-e3e67780fc1a
-    /hee:contentBlocks[12]:
+    /hee:contentBlocks[13]:
       jcr:primaryType: hee:contentCards
       hee:cardGroupSummary: "Eros tristique tincidunt massa consectetur aliquam mi\
         \ tempus maximus ac suspendisse erat nisi rutrum mi orci phasellus euismod\

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/components.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/components.ftl
@@ -15,3 +15,4 @@
 <#include "anchor-links.ftl">
 <#include "media.ftl">
 <#include "tabs.ftl">
+<#include "details.ftl">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/details.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/details.ftl
@@ -1,0 +1,18 @@
+<#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
+
+<#macro details block>
+    <#assign details = block.detailsContentBlock>
+
+    <#if details.summary?? && details.richStatement?? >
+        <details class="nhsuk-details">
+            <summary class="nhsuk-details__summary">
+            <span class="nhsuk-details__summary-text">
+               ${details.summary}
+            </span>
+            </summary>
+            <div class="nhsuk-details__text">
+                <@hst.html hippohtml=details.richStatement/>
+            </div>
+        </details>
+    </#if>
+</#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
@@ -62,6 +62,9 @@
                                             <#case "uk.nhs.hee.web.beans.ContentCards">
                                                 <@hee.contentCards contentCards=block size="half"/>
                                                 <#break>
+                                            <#case "uk.nhs.hee.web.beans.DetailsReference">
+                                                <@hee.details block=block/>
+                                                <#break>
                                             <#default>
                                         </#switch>
                                     </#list>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/homepage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/homepage-main.ftl
@@ -77,6 +77,9 @@
                                     <#case "uk.nhs.hee.web.beans.TabsReference">
                                         <@hee.tabs tabs=block/>
                                         <#break>
+                                    <#case "uk.nhs.hee.web.beans.DetailsReference">
+                                        <@hee.details block=block/>
+                                        <#break>
                                     <#default>
                                 </#switch>
                             </#list>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/Details.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/Details.java
@@ -1,0 +1,19 @@
+package uk.nhs.hee.web.beans;
+
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+
+@HippoEssentialsGenerated(internalName = "hee:details")
+@Node(jcrType = "hee:details")
+public class Details extends BaseDocument {
+    @HippoEssentialsGenerated(internalName = "hee:summary")
+    public String getSummary() {
+        return getSingleProperty("hee:summary");
+    }
+
+    @HippoEssentialsGenerated(internalName = "hee:richStatement")
+    public HippoHtml getRichStatement() {
+        return getHippoHtml("hee:richStatement");
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/DetailsReference.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/DetailsReference.java
@@ -1,0 +1,15 @@
+package uk.nhs.hee.web.beans;
+
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+
+@HippoEssentialsGenerated(internalName = "hee:detailsReference")
+@Node(jcrType = "hee:detailsReference")
+public class DetailsReference extends HippoCompound {
+    @HippoEssentialsGenerated(internalName = "hee:detailsContentBlock")
+    public HippoBean getDetailsContentBlock() {
+        return getLinkedBean("hee:detailsContentBlock", HippoBean.class);
+    }
+}


### PR DESCRIPTION
https://hee-tis.atlassian.net/browse/NWPS-412 

I have created:
 - a new Details document type
 - a new Details (reusable) compound type
 - added Details (reusable) compound type to the list of allowed content blocks for the guidance pages and home page
 - added template query for the Details document type that is used to restrict the content that can be created inside a folder. 
 - added an example of Details document type and updated the the [Home Page](http://localhost:8080/site/knowledge-staff) and [Guidance Page](http://localhost:8080/site/copyright) to display it. 
