### PR TITLE
Fix Details macro to allow multiple details components to be used inside a page

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/details.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/details.ftl
@@ -1,17 +1,17 @@
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
 
 <#macro details block>
-    <#assign details = block.detailsContentBlock>
+    <#assign detailsDocument = block.detailsContentBlock>
 
-    <#if details.summary?? && details.richStatement?? >
+    <#if detailsDocument.summary?? && detailsDocument.richStatement?? >
         <details class="nhsuk-details">
             <summary class="nhsuk-details__summary">
             <span class="nhsuk-details__summary-text">
-               ${details.summary}
+               ${detailsDocument.summary}
             </span>
             </summary>
             <div class="nhsuk-details__text">
-                <@hst.html hippohtml=details.richStatement/>
+                <@hst.html hippohtml=detailsDocument.richStatement/>
             </div>
         </details>
     </#if>


### PR DESCRIPTION
[NWPS-852](https://hee-tis.atlassian.net/browse/NWPS-852)

I have renamed the variable "details" used inside the "details" macro to avoid the name clash. 

The issue was caused because once the macro was used in the page, next time the page was trying to include the details macro using  <**@hee.details** block=block/>  the user-defined directive "@hee.details" was pointing to the variable value instead of the macro. 