### PR TITLE
NWPS-1186-Remove-URL-Redirect-Digital-Academy

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/digital-transformation/logicmodelreportpdfredirect.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/digital-transformation/logicmodelreportpdfredirect.yaml
@@ -3,7 +3,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: 4bd15f43-9b33-46e9-9e7c-3c1a183795cf
   hippo:name: LogicModelReportPDFRedirect
-  hippo:versionHistory: 1a03d24d-8cce-44af-b504-6438bb823174
+  hippo:versionHistory: 0b5322fd-d9c8-474f-a2e2-e11b4454b1b5
   /logicmodelreportpdfredirect[1]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:versionable']
@@ -52,7 +52,7 @@
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable']
     jcr:uuid: 52ecf67b-8d06-4c1c-aa16-e2a8c2d9c05b
-    hippo:availability: [live]
+    hippo:availability: []
     hippostd:retainable: false
     hippostd:state: published
     hippostd:transferable: false

--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/digital-transformation/revertshorteneddigitalacademy.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/digital-transformation/revertshorteneddigitalacademy.yaml
@@ -1,0 +1,83 @@
+/content/urlrewriter/digital-transformation/revertshorteneddigitalacademy:
+  jcr:primaryType: hippo:handle
+  jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
+  jcr:uuid: edc760b6-7868-4668-9e58-4c28514fac17
+  hippo:name: RevertShortenedDigitalAcademy
+  hippo:versionHistory: 7c1c00e2-c738-4171-a1f5-464ca49c7658
+  /revertshorteneddigitalacademy[1]:
+    jcr:primaryType: urlrewriter:xmlrule
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: ae585b6d-3eb0-4191-bf23-b44e0c94dc61
+    hippo:availability: []
+    hippostd:retainable: false
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2022-11-09T15:29:28.256Z
+    hippostdpubwf:lastModificationDate: 2022-11-09T15:31:50.524Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2008-03-26T12:03:00+01:00
+    urlrewriter:rule: "<rule>\r\n<name>Revert Shortened Digital Academy for host 'digital-transformation.hee.nhs.uk'</name>\r\
+      \n<condition name=\"host\" operator=\"equal\">digital-transformation.hee.nhs.uk</condition>\r\
+      \n<from>^/learning-and-development/digital-academy/?$</from>\r\n<to type=\"\
+      temporary-redirect\" last=\"true\">/digital-academy</to>\r\n</rule>\r\n<rule>\r\
+      \n<condition name=\"host\" operator=\"equal\">digital-transformation.hee.nhs.uk</condition>\r\
+      \n<from>^/learning-and-development/digital-academy</from>\r\n<to type=\"temporary-redirect\"\
+      \ last=\"true\">/digital-academy</to>\r\n</rule>\r\n\r\n<rule>\r\n<name>Revert\
+      \ Shortened Digital Academy for hosts other than 'hee.nhs.uk' host</name>\r\n\
+      <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\n<from>^/digital-transformation/learning-and-development/digital-academy/?$</from>\r\
+      \n<to type=\"temporary-redirect\" last=\"true\">/site/digital-transformation/digital-academy</to>\r\
+      \n</rule>\r\n<rule>\r\n<condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
+      \n<from>^/digital-transformation/learning-and-development/digital-academy</from>\r\
+      \n<to type=\"temporary-redirect\" last=\"true\">/site/digital-transformation/digital-academy</to>\r\
+      \n</rule>"
+  /revertshorteneddigitalacademy[2]:
+    jcr:primaryType: urlrewriter:xmlrule
+    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+    jcr:uuid: a9a3d62e-1ab6-4cce-8cc3-f559858a9910
+    hippo:availability: [preview]
+    hippostd:retainable: false
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2022-11-09T15:29:28.256Z
+    hippostdpubwf:lastModificationDate: 2022-11-09T15:34:27.031Z
+    hippostdpubwf:lastModifiedBy: admin
+    urlrewriter:rule: "<rule>\r\n<name>Revert Shortened Digital Academy for host 'digital-transformation.hee.nhs.uk'</name>\r\
+      \n<condition name=\"host\" operator=\"equal\">digital-transformation.hee.nhs.uk</condition>\r\
+      \n<from>^/learning-and-development/digital-academy/?$</from>\r\n<to type=\"\
+      temporary-redirect\" last=\"true\">/digital-academy</to>\r\n</rule>\r\n<rule>\r\
+      \n<condition name=\"host\" operator=\"equal\">digital-transformation.hee.nhs.uk</condition>\r\
+      \n<from>^/learning-and-development/digital-academy</from>\r\n<to type=\"temporary-redirect\"\
+      \ last=\"true\">/digital-academy</to>\r\n</rule>\r\n\r\n<rule>\r\n<name>Revert\
+      \ Shortened Digital Academy for hosts other than 'hee.nhs.uk' host</name>\r\n\
+      <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\n<from>^/digital-transformation/learning-and-development/digital-academy/?$</from>\r\
+      \n<to type=\"temporary-redirect\" last=\"true\">/site/digital-transformation/digital-academy</to>\r\
+      \n</rule>\r\n<rule>\r\n<condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
+      \n<from>^/digital-transformation/learning-and-development/digital-academy</from>\r\
+      \n<to type=\"temporary-redirect\" last=\"true\">/site/digital-transformation/digital-academy</to>\r\
+      \n</rule>"
+  /revertshorteneddigitalacademy[3]:
+    jcr:primaryType: urlrewriter:xmlrule
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: 92357221-22a1-4b5f-8786-45e44aab5123
+    hippo:availability: [live]
+    hippostd:retainable: false
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2022-11-09T15:29:28.256Z
+    hippostdpubwf:lastModificationDate: 2022-11-09T15:34:27.031Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2022-11-09T15:34:29.286Z
+    urlrewriter:rule: "<rule>\r\n<name>Revert Shortened Digital Academy for host 'digital-transformation.hee.nhs.uk'</name>\r\
+      \n<condition name=\"host\" operator=\"equal\">digital-transformation.hee.nhs.uk</condition>\r\
+      \n<from>^/learning-and-development/digital-academy/?$</from>\r\n<to type=\"\
+      temporary-redirect\" last=\"true\">/digital-academy</to>\r\n</rule>\r\n<rule>\r\
+      \n<condition name=\"host\" operator=\"equal\">digital-transformation.hee.nhs.uk</condition>\r\
+      \n<from>^/learning-and-development/digital-academy</from>\r\n<to type=\"temporary-redirect\"\
+      \ last=\"true\">/digital-academy</to>\r\n</rule>\r\n\r\n<rule>\r\n<name>Revert\
+      \ Shortened Digital Academy for hosts other than 'hee.nhs.uk' host</name>\r\n\
+      <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\n<from>^/digital-transformation/learning-and-development/digital-academy/?$</from>\r\
+      \n<to type=\"temporary-redirect\" last=\"true\">/site/digital-transformation/digital-academy</to>\r\
+      \n</rule>\r\n<rule>\r\n<condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
+      \n<from>^/digital-transformation/learning-and-development/digital-academy</from>\r\
+      \n<to type=\"temporary-redirect\" last=\"true\">/site/digital-transformation/digital-academy</to>\r\
+      \n</rule>"

--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/digital-transformation/searchtosearchresultsredirect.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/digital-transformation/searchtosearchresultsredirect.yaml
@@ -1,4 +1,5 @@
 /content/urlrewriter/digital-transformation/searchtosearchresultsredirect:
+  .meta:order-before: revertshorteneddigitalacademy
   jcr:primaryType: hippo:handle
   jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
   jcr:uuid: b56f6194-092c-4fe9-8d35-f4c5bb9d6b8c

--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/digital-transformation/shorteneddigitalacademy.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/digital-transformation/shorteneddigitalacademy.yaml
@@ -1,9 +1,10 @@
 /content/urlrewriter/digital-transformation/shorteneddigitalacademy:
+  .meta:order-before: revertshorteneddigitalacademy
   jcr:primaryType: hippo:handle
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: b8de65a1-c0c1-4cbd-bd5d-80c5a82928a1
   hippo:name: ShortenedDigitalAcademy
-  hippo:versionHistory: 637263b9-d80d-4101-9c5b-ee3f1efcaaae
+  hippo:versionHistory: 6a7810af-9d58-480f-a108-5989f2128a69
   /shorteneddigitalacademy[1]:
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:versionable']
@@ -31,15 +32,20 @@
     hippo:availability: []
     hippostd:retainable: false
     hippostd:state: draft
+    hippostd:transferable: false
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-12-23T12:44:13.900Z
-    hippostdpubwf:lastModificationDate: 2022-01-27T17:09:18.266Z
+    hippostdpubwf:lastModificationDate: 2022-11-09T15:29:42.653Z
     hippostdpubwf:lastModifiedBy: admin
-    urlrewriter:rule: "<rule>\r\n    <name>Shortened Digital Academy for host 'digital-transformation.hee.nhs.uk'</name>\r\
+    urlrewriter:rule: "<rule>\r\n<name>Shortened Digital Academy for host 'digital-transformation.hee.nhs.uk'</name>\r\
+      \n<condition name=\"host\" operator=\"equal\">digital-transformation.hee.nhs.uk</condition>\r\
+      \n<from>^/digital-academy$</from>\r\n<to type=\"temporary-redirect\" last=\"\
+      true\">/learning-and-development/digital-academy</to>\r\n</rule>\r\n\r\n\r\n\
+      <rule>\r\n    <name>Shortened Digital Academy for host 'digital-transformation.hee.nhs.uk'</name>\r\
       \n    <condition name=\"host\" operator=\"equal\">digital-transformation.hee.nhs.uk</condition>\r\
       \n    <from>^/digital-academy$</from>\r\n    <to type=\"temporary-redirect\"\
       \ last=\"true\">/learning-and-development/digital-academy</to>\r\n</rule>\r\n\
-      \r\n<rule>\r\n    <name>Shortened Digital Academy for hosts other than 'hee.nhs.uk'\
+      <rule>\r\n    <name>Shortened Digital Academy for hosts other than 'hee.nhs.uk'\
       \ host</name>\r\n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
       \n    <from>^/digital-transformation/digital-academy$</from>\r\n    <to type=\"\
       temporary-redirect\" last=\"true\">/site/digital-transformation/learning-and-development/digital-academy</to>\r\
@@ -48,7 +54,7 @@
     jcr:primaryType: urlrewriter:xmlrule
     jcr:mixinTypes: ['mix:referenceable']
     jcr:uuid: 3c73c571-1b0b-4295-9cdd-b594fac79cc7
-    hippo:availability: [live]
+    hippo:availability: []
     hippostd:retainable: false
     hippostd:state: published
     hippostdpubwf:createdBy: admin


### PR DESCRIPTION
Please review this ticket.  

1. Created new url rewriter XML rule - RevertShortenedDigitalAcademy - this will redirect all /learning-and-development/digital-academy/ to /digital-academy/  & /learning-and-development/digital-academy/* to /digital-academy/*
2. Unpublished url rewriter - ShortenedDigitalAcademy 
3. Unpublished url rewriter - LogicModelReportPDFRedirect - This can be deleted as we are using #1 rule, but to be verified during production

During LIVE, there are perquisites needs to be completed as I explained on JIRA ticket