### PR TITLE
[WSP-1157] Upgrade/brxm cms upgrade 16.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: 'zulu'
           java-version: 17
           # Creates ~/.m2/settings.xml server entry for auth 【5-4ce7fa】
-          server-id: hippo-maven2-enterprise
+          server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: CI
 
-# Continuous Integration on develop, release/** & master branches will be done part of Continuous Deployment workflow
 on:
   push:
     branches-ignore:
@@ -16,25 +15,18 @@ jobs:
       BLOOMREACH_MVN_PASSWORD: ${{ secrets.BLOOMREACH_MVN_PASSWORD }}
 
     steps:
-      - name: Check out repo.
-        uses: actions/checkout@v6  # Node24-capable major 【3-6a53d0】
+      - name: Check out repo
+        uses: actions/checkout@v6
 
-      - name: Set up JDK 17 (with Maven auth)
-        uses: actions/setup-java@v5  # Updated to Node24 internally 【4-65ce2e】
+      - name: Set up JDK 17 with Maven auth
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 17
-          # Creates ~/.m2/settings.xml server entry for auth 【5-4ce7fa】
+          cache: 'maven'
           server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
-
-      - name: Cache maven packages
-        uses: actions/cache@v5  # Runs on Node24 runtime 【2-6e95d6】
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
 
       - name: Compile
         run: mvn -B clean compile -Pdefault --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Check out repo.
         uses: actions/checkout@v6  # Node24-capable major 【3-6a53d0】
 
-      - name: Set up JDK 11 (with Maven auth)
+      - name: Set up JDK 17 (with Maven auth)
         uses: actions/setup-java@v5  # Updated to Node24 internally 【4-65ce2e】
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           # Creates ~/.m2/settings.xml server entry for auth 【5-4ce7fa】
           server-id: hippo-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME

--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Check out repo.
         uses: actions/checkout@v6  # Node24-capable major 【2-3c4523】
 
-      - name: Set up JDK 11 (with Maven auth)
+      - name: Set up JDK 17 (with Maven auth)
         uses: actions/setup-java@v5  # Updated to Node24 internally 【3-2487d8】
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           # Creates ~/.m2/settings.xml server entry for auth 【4-fb1b8b】
           server-id: hippo-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
@@ -62,11 +62,11 @@ jobs:
       - name: Check out repo.
         uses: actions/checkout@v6  # Node24-capable major 【2-3c4523】
 
-      - name: Set up JDK 11 (with Maven auth)
+      - name: Set up JDK 17 (with Maven auth)
         uses: actions/setup-java@v5  # Updated to Node24 internally 【3-2487d8】
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           # Creates ~/.m2/settings.xml server entry for auth 【4-fb1b8b】
           server-id: hippo-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME

--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: 'zulu'
           java-version: 17
           # Creates ~/.m2/settings.xml server entry for auth 【4-fb1b8b】
-          server-id: hippo-maven2-enterprise
+          server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
 
@@ -68,7 +68,7 @@ jobs:
           distribution: 'zulu'
           java-version: 17
           # Creates ~/.m2/settings.xml server entry for auth 【4-fb1b8b】
-          server-id: hippo-maven2-enterprise
+          server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
 

--- a/.github/workflows/cicd-upgrade-v16.yml
+++ b/.github/workflows/cicd-upgrade-v16.yml
@@ -1,9 +1,9 @@
-name: CI & CD [RELEASE]
+name: CI & CD [MASTER]
 
 on:
   push:
-    tags:
-      - release-**
+    branches:
+      - upgrade/brxm-cms-upgrade-16.9.2
 
 env:
   BRC_STACK_NAME: hee
@@ -39,14 +39,15 @@ jobs:
       - name: Test
         run: mvn -B clean test -Pdefault --file pom.xml
 
-  deploy:
-    name: Deploy to Production Env. [on brCloud]
-    environment: production
-    needs: buildAndTest
+
+  deploy-to-test:
+    name: Deploy to Test Env. [on brCloud]
+    needs: [buildAndTest]
+    environment: test
     runs-on: ubuntu-latest
 
     env:
-      BRC_ENV_NAME: production
+      BRC_ENV_NAME: test
       BLOOMREACH_MVN_USERNAME: ${{ secrets.BLOOMREACH_MVN_USERNAME }}
       BLOOMREACH_MVN_PASSWORD: ${{ secrets.BLOOMREACH_MVN_PASSWORD }}
 
@@ -78,7 +79,6 @@ jobs:
           brcStack: ${{ env.BRC_STACK_NAME }}
           username: ${{ secrets.BRC_USERNAME }}
           password: ${{ secrets.BRC_PASSWORD }}
-          # maxDistributions: ${{ env.BRC_MAX_DISTRIBUTIONS }}
           distributionsDeleteCount: ${{ env.BRC_DISTRIBUTION_DELETE_COUNT }}
 
       - name: Upload distribution to Bloomreach Cloud
@@ -90,7 +90,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distPath: ${{ steps.dist.outputs.distPath }}
 
-      - name: Deploy distribution to production env
+      - name: Deploy distribution to test env
         uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.7
         id: deploy
         with:
@@ -99,4 +99,4 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
-          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties,hee-new-relic.properties'
+          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-          server-id: hippo-maven2-enterprise
+          server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
 
@@ -67,7 +67,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-          server-id: hippo-maven2-enterprise
+          server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
 
@@ -138,7 +138,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-          server-id: hippo-maven2-enterprise
+          server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
 
@@ -207,7 +207,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-          server-id: hippo-maven2-enterprise
+          server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Check out repo.
         uses: actions/checkout@v6  # Node24-capable major 【2-a6cf69】
 
-      - name: Set up JDK 11 (with Maven auth)
+      - name: Set up JDK 17 (with Maven auth)
         uses: actions/setup-java@v5  # Updated to Node24 internally 【4-e6304f】
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           server-id: hippo-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
@@ -62,11 +62,11 @@ jobs:
       - name: Check out repo.
         uses: actions/checkout@v6
 
-      - name: Set up JDK 11 (with Maven auth)
+      - name: Set up JDK 17 (with Maven auth)
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           server-id: hippo-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
@@ -133,11 +133,11 @@ jobs:
       - name: Check out repo.
         uses: actions/checkout@v6
 
-      - name: Set up JDK 11 (with Maven auth)
+      - name: Set up JDK 17 (with Maven auth)
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           server-id: hippo-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
@@ -202,11 +202,11 @@ jobs:
       - name: Check out repo.
         uses: actions/checkout@v6
 
-      - name: Set up JDK 11 (with Maven auth)
+      - name: Set up JDK 17 (with Maven auth)
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           server-id: hippo-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,24 +20,18 @@ jobs:
       BLOOMREACH_MVN_PASSWORD: ${{ secrets.BLOOMREACH_MVN_PASSWORD }}
 
     steps:
-      - name: Check out repo.
-        uses: actions/checkout@v6  # Node24-capable major 【2-a6cf69】
+      - name: Check out repo
+        uses: actions/checkout@v6
 
-      - name: Set up JDK 17 (with Maven auth)
-        uses: actions/setup-java@v5  # Updated to Node24 internally 【4-e6304f】
+      - name: Set up JDK 17 with Maven auth
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 17
+          cache: 'maven'
           server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
-
-      - name: Cache maven packages
-        uses: actions/cache@v5  # Runs on Node24 runtime 【3-608c06】
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
 
       - name: Compile
         run: mvn -B clean compile -Pdefault --file pom.xml
@@ -50,38 +44,31 @@ jobs:
     name: Deploy to Dev Env. [on brCloud]
     needs: buildAndTest
     environment: development
+    runs-on: ubuntu-latest
 
     env:
       BRC_ENV_NAME: development
       BLOOMREACH_MVN_USERNAME: ${{ secrets.BLOOMREACH_MVN_USERNAME }}
       BLOOMREACH_MVN_PASSWORD: ${{ secrets.BLOOMREACH_MVN_PASSWORD }}
 
-    runs-on: ubuntu-latest
-
     steps:
-      - name: Check out repo.
+      - name: Check out repo
         uses: actions/checkout@v6
 
-      - name: Set up JDK 17 (with Maven auth)
+      - name: Set up JDK 17 with Maven auth
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 17
+          cache: 'maven'
           server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
 
-      - name: Cache maven packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
       - name: Package
         run: mvn -B verify && mvn -Pdist -Denv=${{ env.BRC_ENV_NAME }} --file pom.xml
 
-      - name: Setting distribution path (distPath) as an output parameter
+      - name: Setting distribution path distPath as an output parameter
         id: dist
         run: echo "distPath=$(ls -1 ${{ github.workspace }}/target/$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)-$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$(git rev-parse --short "$GITHUB_SHA")-${{ env.BRC_ENV_NAME }}-*.tar.gz)" >> $GITHUB_OUTPUT
 
@@ -104,7 +91,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distPath: ${{ steps.dist.outputs.distPath }}
 
-      - name: Deploy distribution to 'development' env
+      - name: Deploy distribution to development env
         uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.7
         id: deploy
         with:
@@ -121,38 +108,31 @@ jobs:
     if: ${{ false }}
     needs: [buildAndTest, deploy-to-dev]
     environment: test
+    runs-on: ubuntu-latest
 
     env:
       BRC_ENV_NAME: test
       BLOOMREACH_MVN_USERNAME: ${{ secrets.BLOOMREACH_MVN_USERNAME }}
       BLOOMREACH_MVN_PASSWORD: ${{ secrets.BLOOMREACH_MVN_PASSWORD }}
 
-    runs-on: ubuntu-latest
-
     steps:
-      - name: Check out repo.
+      - name: Check out repo
         uses: actions/checkout@v6
 
-      - name: Set up JDK 17 (with Maven auth)
+      - name: Set up JDK 17 with Maven auth
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 17
+          cache: 'maven'
           server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
 
-      - name: Cache maven packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
       - name: Package
         run: mvn -B verify && mvn -Pdist -Denv=${{ env.BRC_ENV_NAME }} --file pom.xml
 
-      - name: Setting distribution path (distPath) as an output parameter
+      - name: Setting distribution path distPath as an output parameter
         id: dist
         run: echo "distPath=$(ls -1 ${{ github.workspace }}/target/$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)-$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$(git rev-parse --short "$GITHUB_SHA")-${{ env.BRC_ENV_NAME }}-*.tar.gz)" >> $GITHUB_OUTPUT
 
@@ -174,7 +154,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distPath: ${{ steps.dist.outputs.distPath }}
 
-      - name: Deploy distribution to 'test' env
+      - name: Deploy distribution to test env
         uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.7
         id: deploy
         with:
@@ -190,38 +170,31 @@ jobs:
     name: Deploy to Staging Env. [on brCloud]
     needs: [buildAndTest]
     environment: staging
+    runs-on: ubuntu-latest
 
     env:
       BRC_ENV_NAME: staging
       BLOOMREACH_MVN_USERNAME: ${{ secrets.BLOOMREACH_MVN_USERNAME }}
       BLOOMREACH_MVN_PASSWORD: ${{ secrets.BLOOMREACH_MVN_PASSWORD }}
 
-    runs-on: ubuntu-latest
-
     steps:
-      - name: Check out repo.
+      - name: Check out repo
         uses: actions/checkout@v6
 
-      - name: Set up JDK 17 (with Maven auth)
+      - name: Set up JDK 17 with Maven auth
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 17
+          cache: 'maven'
           server-id: bloomreach-maven2-enterprise
           server-username: BLOOMREACH_MVN_USERNAME
           server-password: BLOOMREACH_MVN_PASSWORD
 
-      - name: Cache maven packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
       - name: Package
         run: mvn -B verify && mvn -Pdist -Denv=${{ env.BRC_ENV_NAME }} --file pom.xml
 
-      - name: Setting distribution path (distPath) as an output parameter
+      - name: Setting distribution path distPath as an output parameter
         id: dist
         run: echo "distPath=$(ls -1 ${{ github.workspace }}/target/$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)-$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$(git rev-parse --short "$GITHUB_SHA")-${{ env.BRC_ENV_NAME }}-*.tar.gz)" >> $GITHUB_OUTPUT
 
@@ -243,7 +216,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distPath: ${{ steps.dist.outputs.distPath }}
 
-      - name: Deploy distribution to 'staging' env
+      - name: Deploy distribution to staging env
         uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.7
         id: deploy
         with:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The HEE CMS Platform used to manage and deliver the website at https://www.hee.n
 
 ## Built With
 
-* [BloomReach DXP 16.0.0](http://www.bloomreach.com) - BloomReach is the content management system platform used in this project
+* [BloomReach DXP 16.9.2](http://www.bloomreach.com) - BloomReach is the content management system platform used in this project
 * [brCloud](https://www.bloomreach.com/en/products/experience-manager/cloud-cms) - Bloomreach Cloud Managed Hosting
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The HEE CMS Platform used to manage and deliver the website at https://www.hee.n
 
 ## Built With
 
-* [BloomReach DXP 15.7.0](http://www.bloomreach.com) - BloomReach is the content management system platform used in this project
+* [BloomReach DXP 16.0.0](http://www.bloomreach.com) - BloomReach is the content management system platform used in this project
 * [brCloud](https://www.bloomreach.com/en/products/experience-manager/cloud-cms) - Bloomreach Cloud Managed Hosting
 
 ## Getting Started
@@ -21,7 +21,7 @@ In order to develop on this platform you will need to have the following tools i
 
 - IntelliJ IDEA
 - Docker
-- Java 11
+- Java 17
 - Maven >= 3.5.0 (For `Maven CI Friendly Versions` Support)
 
 
@@ -178,7 +178,7 @@ Please check the following diagram for a better understanding of the development
 
 The GitHub action workflows that handle the CICD process require the following secrets to be setup on Github:
 
-- Secrets for `hippo-maven2-enterprise` maven repository (https://maven.onehippo.com/maven2-enterprise)
+- Secrets for `bloomreach-maven2-enterprise` maven repository (https://maven.onehippo.com/maven2-enterprise)
    - BLOOMREACH_MVN_USERNAME - brXM Maven Repository username
    - BLOOMREACH_MVN_PASSWORD - brXM Maven Repository password
 

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -26,6 +26,12 @@
     </dependency>
 
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
@@ -36,13 +42,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
     </dependency>
   </dependencies>
   <build>
@@ -77,7 +78,7 @@
       </plugin>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
+        <artifactId>cargo-maven3-plugin</artifactId>
         <configuration>
           <configuration>
             <type>runtime</type>

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -45,6 +45,11 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <finalName>cms</finalName>

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
   <build>

--- a/cms/src/main/java/uk/nhs/hee/web/configuration/channel/listener/PostBluePrintChannelCreationTasksListener.java
+++ b/cms/src/main/java/uk/nhs/hee/web/configuration/channel/listener/PostBluePrintChannelCreationTasksListener.java
@@ -10,6 +10,7 @@ import uk.nhs.hee.web.yaml.YAMLImporter;
 
 import javax.jcr.RepositoryException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -46,7 +47,7 @@ public class PostBluePrintChannelCreationTasksListener implements ChannelManager
                     )
             );
             yamlImporter.importFiles();
-        } catch (final RepositoryException | IOException e) {
+        } catch (final RepositoryException | IOException | UncheckedIOException e) {
             LOGGER.error(
                     "Caught error {} while performing post blueprint channel creation tasks",
                     e.getMessage(),

--- a/cms/src/main/java/uk/nhs/hee/web/repository/documentworkflow/DocumentWorkflowImplWithoutCopyOperation.java
+++ b/cms/src/main/java/uk/nhs/hee/web/repository/documentworkflow/DocumentWorkflowImplWithoutCopyOperation.java
@@ -48,7 +48,7 @@ public class DocumentWorkflowImplWithoutCopyOperation extends DocumentWorkflowIm
      * @throws WorkflowException thrown when a workflow implementation disallows
      *                           the workflow step to be taken for some reason.
      */
-    private Map<String, Serializable> getHints(final String branchId) throws WorkflowException {
+    protected Map<String, Serializable> getHints(final String branchId) throws WorkflowException {
         return super.hints(branchId);
     }
 }

--- a/cms/src/main/java/uk/nhs/hee/web/repository/scheduling/NextReviewDateNotification.java
+++ b/cms/src/main/java/uk/nhs/hee/web/repository/scheduling/NextReviewDateNotification.java
@@ -19,7 +19,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
-import javax.mail.MessagingException;
+import jakarta.mail.MessagingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -180,7 +180,7 @@ public class NextReviewDateNotification implements RepositoryJob {
                     StringUtils.trim(context.getAttribute(ATTRIBUTE_EMAIL_BODY_PLAIN_TEXT_TEMPLATE));
 
             // Create mail session
-            final javax.mail.Session mailSession = MailUtils.getMailSession();
+            final jakarta.mail.Session mailSession = MailUtils.getMailSession();
             if (mailSession == null) {
                 LOGGER.warn("Email session isn't available. Halting the job for now!");
                 return;

--- a/cms/src/main/java/uk/nhs/hee/web/utils/MailUtils.java
+++ b/cms/src/main/java/uk/nhs/hee/web/utils/MailUtils.java
@@ -4,10 +4,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.mail.Address;
-import javax.mail.Session;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
+import jakarta.mail.Address;
+import jakarta.mail.Session;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -77,7 +77,7 @@ public class MailUtils {
         try {
             initialContext = new InitialContext();
             final Context context = (Context) initialContext.lookup("java:comp/env");
-            return (javax.mail.Session) context.lookup(MAIL_SESSION_NAME);
+            return (jakarta.mail.Session) context.lookup(MAIL_SESSION_NAME);
         } catch (final NamingException e) {
             LOGGER.error("Error creating email session: {}", MAIL_SESSION_NAME, e);
             try {

--- a/cms/src/main/java/uk/nhs/hee/web/yaml/YAMLImporter.java
+++ b/cms/src/main/java/uk/nhs/hee/web/yaml/YAMLImporter.java
@@ -16,6 +16,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.CodeSource;
@@ -97,7 +98,7 @@ public class YAMLImporter {
                 }
 
                 importYAML(yaml, getParentNodePath(yaml));
-            } catch (final RepositoryException | IOException e) {
+            } catch (final RepositoryException | IOException | UncheckedIOException e) {
                 LOGGER.error(
                         "Caught error '{}' while importing the Yaml file '{}'",
                         e.getMessage(),
@@ -130,14 +131,14 @@ public class YAMLImporter {
                 parentNode);
     }
 
-    private String getParentNodePath(final String plainYaml) throws IOException {
+    private String getParentNodePath(final String plainYaml) {
         try {
             // Get the first line of the YAML which should essentially contain the node path.
             final String nodePath = IOUtils.readLines(new StringReader(plainYaml)).get(0);
 
             // Returns parent node path of the node
             return nodePath.substring(0, nodePath.lastIndexOf('/'));
-        } catch (final IOException e) {
+        } catch (final UncheckedIOException e) {
             LOGGER.error(
                     "Caught error {} while retrieving parent node path from YAML: {}",
                     e.getMessage(),

--- a/cms/src/main/webapp/WEB-INF/web.xml
+++ b/cms/src/main/webapp/WEB-INF/web.xml
@@ -38,11 +38,6 @@
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 
-  <!--No concurrent logins-->
-  <filter>
-    <filter-name>ConcurrentLogin</filter-name>
-    <filter-class>org.hippoecm.frontend.plugins.login.ConcurrentLoginFilter</filter-class>
-  </filter>
 
   <!--Default application-->
   <filter>
@@ -97,11 +92,6 @@
   </filter>
 
   <filter-mapping>
-    <filter-name>ConcurrentLogin</filter-name>
-    <url-pattern>/*</url-pattern>
-  </filter-mapping>
-
-  <filter-mapping>
     <filter-name>CMS</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
@@ -110,10 +100,6 @@
     <filter-name>Console</filter-name>
     <url-pattern>/console/*</url-pattern>
   </filter-mapping>
-
-  <listener>
-    <listener-class>org.hippoecm.frontend.plugins.login.ConcurrentLoginListener</listener-class>
-  </listener>
 
   <servlet>
     <servlet-name>AngularResourceServlet</servlet-name>

--- a/cms/src/test/java/uk/nhs/hee/web/repository/documentworkflow/DocumentWorkflowImplWithoutCopyOperationTest.java
+++ b/cms/src/test/java/uk/nhs/hee/web/repository/documentworkflow/DocumentWorkflowImplWithoutCopyOperationTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "javax.script.*"})
+@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
 @PrepareForTest({DocumentWorkflowImplWithoutCopyOperation.class})
 public class DocumentWorkflowImplWithoutCopyOperationTest {
 

--- a/cms/src/test/java/uk/nhs/hee/web/repository/documentworkflow/DocumentWorkflowImplWithoutCopyOperationTest.java
+++ b/cms/src/test/java/uk/nhs/hee/web/repository/documentworkflow/DocumentWorkflowImplWithoutCopyOperationTest.java
@@ -3,23 +3,18 @@ package uk.nhs.hee.web.repository.documentworkflow;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.times;
-import static org.powermock.api.mockito.PowerMockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
-@PrepareForTest({DocumentWorkflowImplWithoutCopyOperation.class})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DocumentWorkflowImplWithoutCopyOperationTest {
 
     private final HashMap<String, Serializable> originalHints = new HashMap<String, Serializable>() {
@@ -42,18 +37,13 @@ public class DocumentWorkflowImplWithoutCopyOperationTest {
 
     @Test
     public void hints_VerifyThatTheCopyOperationHasBeenRemoved() throws Exception {
-        // Mocks & stubs
-        doReturn(originalHints).when(systemUnderTest, "getHints", Mockito.anyString());
+        doReturn(originalHints).when(systemUnderTest).getHints(anyString());
 
-        // Execute the method to be tested
         final Map<String, Serializable> actualHints = systemUnderTest.hints("master");
 
-        // Verify
-        verifyPrivate(systemUnderTest, times(1)).invoke("getHints", any(String.class));
+        verify(systemUnderTest, times(1)).getHints(any(String.class));
         assertThat(actualHints)
                 .doesNotContain(entry("copy", "true"))
                 .contains(entry("delete", "true"), entry("publish", "true"), entry("depublish", "false"));
     }
 }
-
-

--- a/cms/src/test/java/uk/nhs/hee/web/validation/validator/UniqueWebPublicationsValidatorTest.java
+++ b/cms/src/test/java/uk/nhs/hee/web/validation/validator/UniqueWebPublicationsValidatorTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "javax.script.*"})
+@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
 @PrepareForTest({DocumentUtils.class})
 public class UniqueWebPublicationsValidatorTest {
 

--- a/cms/src/test/java/uk/nhs/hee/web/validation/validator/UniqueWebPublicationsValidatorTest.java
+++ b/cms/src/test/java/uk/nhs/hee/web/validation/validator/UniqueWebPublicationsValidatorTest.java
@@ -1,16 +1,16 @@
 package uk.nhs.hee.web.validation.validator;
 
 import org.hippoecm.repository.api.HippoNodeType;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.onehippo.cms.services.validation.api.ValidationContext;
 import org.onehippo.cms.services.validation.api.Violation;
 import org.onehippo.repository.util.JcrConstants;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import uk.nhs.hee.web.utils.DocumentUtils;
 
 import javax.jcr.*;
@@ -21,11 +21,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
-@PrepareForTest({DocumentUtils.class})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class UniqueWebPublicationsValidatorTest {
 
     // Publication landing page document node type
@@ -47,6 +44,8 @@ public class UniqueWebPublicationsValidatorTest {
     private static final String NON_REUSED_PUB_PAGE_DOC_ID = "c5ab67ca-b8b5-4802-9dd9-ee9b4c6b86f0";
 
     private final UniqueWebPublicationsValidator systemUnderTest = new UniqueWebPublicationsValidator();
+
+    private MockedStatic<DocumentUtils> mockedDocumentUtils;
 
     @Mock
     private ValidationContext mockValidationContext;
@@ -70,7 +69,7 @@ public class UniqueWebPublicationsValidatorTest {
     @Before
     public void setUp() throws Exception {
         // Mocks & stubs
-        mockStatic(DocumentUtils.class);
+        mockedDocumentUtils = mockStatic(DocumentUtils.class);
 
         // Publication landing page doc node
         final Node mockPubLandingPageDocHandleNode = mock(Node.class);
@@ -99,7 +98,7 @@ public class UniqueWebPublicationsValidatorTest {
                 .thenReturn(mockNonUniqueWebPubNodeHippoBaseProperty);
         when(mockNonUniqueWebPubNodeHippoBaseProperty.getString()).thenReturn(REUSED_PUB_PAGE_DOC_ID);
 
-        when(DocumentUtils.getDocumentDisplayName(mockSession, REUSED_PUB_PAGE_DOC_ID))
+        mockedDocumentUtils.when(() -> DocumentUtils.getDocumentDisplayName(mockSession, REUSED_PUB_PAGE_DOC_ID))
                 .thenReturn(PUBLICATION_PAGE_HIPPO_NAME);
 
         // Referenced Publication landing page doc query
@@ -126,6 +125,11 @@ public class UniqueWebPublicationsValidatorTest {
         final Violation mockNonUniquePubPageViolation = mock(Violation.class);
         when(mockValidationContext.createViolation(anyMap())).thenReturn(mockNonUniquePubPageViolation);
         when(mockNonUniquePubPageViolation.getMessage()).thenReturn(NON_UNIQUE_PUB_PAGE_VIOLATION_MSG);
+    }
+
+    @After
+    public void tearDown() {
+        mockedDocumentUtils.close();
     }
 
     @Test

--- a/conf/context-dev.xml
+++ b/conf/context-dev.xml
@@ -23,7 +23,7 @@
     <!-- 'mail/Session' JavaMail connection factory JNDI resource -->
     <Resource name="mail/Session"
               auth="Container"
-              type="javax.mail.Session"
+              type="jakarta.mail.Session"
               mail.transport.protocol="smtp"
               mail.smtp.host="${mail.smtp.host}"
               mail.smtp.port="${mail.smtp.port}"

--- a/conf/log4j2-dev.xml
+++ b/conf/log4j2-dev.xml
@@ -103,7 +103,7 @@
     </Logger>
 
     <Logger name="org.apache.cxf" level="warn"/>
-    <Logger name="javax.ws.rs.core" level="warn"/>
+    <Logger name="jakarta.ws.rs.core" level="warn"/>
     <Logger name="org.apache.commons.pool" level="warn"/>
     <Logger name="org.apache.commons.beanutils" level="warn"/>
 

--- a/conf/log4j2-dist.xml
+++ b/conf/log4j2-dist.xml
@@ -78,7 +78,7 @@
 
     <Logger name="freemarker" level="error"/>
     <Logger name="org.apache.cxf" level="error"/>
-    <Logger name="javax.ws.rs.core" level="error"/>
+    <Logger name="jakarta.ws.rs.core" level="error"/>
     <Logger name="org.apache.commons.pool" level="error"/>
     <Logger name="org.apache.commons.beanutils" level="error"/>
 

--- a/conf/log4j2-docker.xml
+++ b/conf/log4j2-docker.xml
@@ -37,7 +37,7 @@
 
     <Logger name="freemarker" level="error"/>
     <Logger name="org.apache.cxf" level="error"/>
-    <Logger name="javax.ws.rs.core" level="error"/>
+    <Logger name="jakarta.ws.rs.core" level="error"/>
     <Logger name="org.apache.commons.pool" level="error"/>
     <Logger name="org.apache.commons.beanutils" level="error"/>
 

--- a/conf/repository-mysql.xml
+++ b/conf/repository-mysql.xml
@@ -7,7 +7,7 @@
 
   <DataSources>
     <DataSource name="repositoryDS">
-      <param name="driver" value="javax.naming.InitialContext"/>
+      <param name="driver" value="jakarta.naming.InitialContext"/>
       <param name="url" value="java:comp/env/jdbc/@mysql.repo.db@"/>
       <param name="databaseType" value="mysql"/>
     </DataSource>

--- a/conf/repository-mysql.xml
+++ b/conf/repository-mysql.xml
@@ -7,7 +7,7 @@
 
   <DataSources>
     <DataSource name="repositoryDS">
-      <param name="driver" value="jakarta.naming.InitialContext"/>
+      <param name="driver" value="javax.naming.InitialContext"/>
       <param name="url" value="java:comp/env/jdbc/@mysql.repo.db@"/>
       <param name="databaseType" value="mysql"/>
     </DataSource>

--- a/conf/repository-postgres.xml
+++ b/conf/repository-postgres.xml
@@ -7,7 +7,7 @@
 
   <DataSources>
     <DataSource name="repositoryDS">
-      <param name="driver" value="javax.naming.InitialContext"/>
+      <param name="driver" value="jakarta.naming.InitialContext"/>
       <param name="url" value="java:comp/env/jdbc/@postgres.repo.db@"/>
       <param name="databaseType" value="postgresql"/>
     </DataSource>

--- a/conf/repository-postgres.xml
+++ b/conf/repository-postgres.xml
@@ -7,7 +7,7 @@
 
   <DataSources>
     <DataSource name="repositoryDS">
-      <param name="driver" value="jakarta.naming.InitialContext"/>
+      <param name="driver" value="javax.naming.InitialContext"/>
       <param name="url" value="java:comp/env/jdbc/@postgres.repo.db@"/>
       <param name="databaseType" value="postgresql"/>
     </DataSource>

--- a/essentials/pom.xml
+++ b/essentials/pom.xml
@@ -43,7 +43,7 @@
     <plugins>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
+        <artifactId>cargo-maven3-plugin</artifactId>
         <configuration>
           <configuration>
             <type>runtime</type>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-enterprise-release</artifactId>
-    <version>15.7.0</version>
+    <version>15.7.3</version>
   </parent>
 
   <name>HEE CMS Platform</name>
@@ -66,7 +66,7 @@
     <!--***START temporary override of versions*** -->
     <!-- ***END temporary override of versions*** -->
 
-    <essentials.version>15.7.0</essentials.version>
+    <essentials.version>15.7.3</essentials.version>
     <jsp-api.version>2.2</jsp-api.version>
     <taglibs.version>1.2.5</taglibs.version>
     <bloomreach.text-search-replace.version>3.0.1</bloomreach.text-search-replace.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-enterprise-release</artifactId>
-    <version>16.9.1</version>
+    <version>16.9.2</version>
   </parent>
 
   <name>HEE CMS Platform</name>
@@ -114,15 +114,15 @@
 
       <!-- other predefined runtime scope versioned dependencies -->
       <dependency>
-        <groupId>org.apache.taglibs</groupId>
-        <artifactId>taglibs-standard-spec</artifactId>
+        <groupId>com.bloomreach.xm</groupId>
+        <artifactId>taglibs-standard-spec-jakarta</artifactId>
         <version>${taglibs.version}</version>
         <scope>runtime</scope>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.taglibs</groupId>
-        <artifactId>taglibs-standard-impl</artifactId>
+        <groupId>com.bloomreach.xm</groupId>
+        <artifactId>taglibs-standard-impl-jakarta</artifactId>
         <version>${taglibs.version}</version>
         <scope>runtime</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-enterprise-release</artifactId>
-    <version>15.7.8</version>
+    <version>16.0.0</version>
   </parent>
 
   <name>HEE CMS Platform</name>
@@ -67,10 +67,8 @@
     <!-- ***END temporary override of versions*** -->
 
     <essentials.version>${hippo.essentials-components.version}</essentials.version>
-    <jsp-api.version>2.2</jsp-api.version>
-    <taglibs.version>1.2.5</taglibs.version>
-    <bloomreach.text-search-replace.version>3.0.1</bloomreach.text-search-replace.version>
-    <jsoup.version>1.15.3</jsoup.version>
+    <bloomreach.text-search-replace.version>4.0.0</bloomreach.text-search-replace.version>
+    <jsoup.version>1.17.2</jsoup.version>
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
     <docker.postgres.bind.1>${project.basedir}/target/postgres-data:/var/lib/postgresql/data</docker.postgres.bind.1>
     <hippo.cms.locales>nl,de,fr,es,zh</hippo.cms.locales>
@@ -79,26 +77,38 @@
 
   <repositories>
     <repository>
-      <id>hippo</id>
-      <name>Hippo maven 2 repository.</name>
+      <id>bloomreach-maven2</id>
+      <name>Bloomreach Maven 2</name>
       <url>https://maven.bloomreach.com/repository/maven2/</url>
+      <snapshots>
+          <enabled>false</enabled>
+      </snapshots>
+      <releases>
+          <updatePolicy>never</updatePolicy>
+          <checksumPolicy>fail</checksumPolicy>
+      </releases>
     </repository>
     <repository>
       <releases>
         <updatePolicy>never</updatePolicy>
         <checksumPolicy>fail</checksumPolicy>
       </releases>
-      <id>hippo-maven2-enterprise</id>
-      <name>Hippo Enterprise Maven 2</name>
+      <id>bloomreach-maven2-enterprise</id>
+      <name>Bloomreach Enterprise Maven 2</name>
       <url>https://maven.bloomreach.com/repository/maven2-enterprise/</url>
+    </repository>
+    <repository>
+        <id>bloomreach-maven2-forge</id>
+        <name>Bloomreach Maven 2 Forge Repository</name>
+        <url>https://maven.bloomreach.com/repository/maven2-forge</url>
     </repository>
   </repositories>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>javax.servlet.jsp</groupId>
-        <artifactId>jsp-api</artifactId>
+        <groupId>jakarta.servlet.jsp</groupId>
+        <artifactId>jakarta.servlet.jsp-api</artifactId>
         <version>${jsp-api.version}</version>
         <scope>provided</scope>
       </dependency>
@@ -390,8 +400,8 @@
           <scope>compile</scope>
         </dependency>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
           <scope>compile</scope>
         </dependency>
         <dependency>
@@ -533,8 +543,8 @@
           <scope>provided</scope>
         </dependency>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
           <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,29 +143,8 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>3.8.0</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito2</artifactId>
-        <version>2.0.9</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-junit4</artifactId>
-        <version>2.0.9</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>3.19.0</version>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -242,7 +221,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.1.0</version>
         <configuration>
           <updatePomFile>true</updatePomFile>
         </configuration>
@@ -419,7 +397,7 @@
         <plugins>
           <plugin>
             <groupId>org.codehaus.cargo</groupId>
-            <artifactId>cargo-maven2-plugin</artifactId>
+            <artifactId>cargo-maven3-plugin</artifactId>
             <configuration>
               <configuration>
                 <configfiles>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-enterprise-release</artifactId>
-    <version>15.7.3</version>
+    <version>15.7.8</version>
   </parent>
 
   <name>HEE CMS Platform</name>
@@ -66,7 +66,7 @@
     <!--***START temporary override of versions*** -->
     <!-- ***END temporary override of versions*** -->
 
-    <essentials.version>15.7.3</essentials.version>
+    <essentials.version>${hippo.essentials-components.version}</essentials.version>
     <jsp-api.version>2.2</jsp-api.version>
     <taglibs.version>1.2.5</taglibs.version>
     <bloomreach.text-search-replace.version>3.0.1</bloomreach.text-search-replace.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-enterprise-release</artifactId>
-    <version>16.0.0</version>
+    <version>16.9.1</version>
   </parent>
 
   <name>HEE CMS Platform</name>
@@ -68,7 +68,6 @@
 
     <essentials.version>${hippo.essentials-components.version}</essentials.version>
     <bloomreach.text-search-replace.version>4.0.0</bloomreach.text-search-replace.version>
-    <jsoup.version>1.17.2</jsoup.version>
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
     <docker.postgres.bind.1>${project.basedir}/target/postgres-data:/var/lib/postgresql/data</docker.postgres.bind.1>
     <hippo.cms.locales>nl,de,fr,es,zh</hippo.cms.locales>
@@ -130,15 +129,15 @@
 
       <!-- other predefined compile scope versioned dependencies -->
       <dependency>
-        <groupId>org.freemarker</groupId>
-        <artifactId>freemarker</artifactId>
-        <version>${freemarker.version}</version>
-      </dependency>
-
-      <dependency>
         <artifactId>jsoup</artifactId>
         <groupId>org.jsoup</groupId>
         <version>${jsoup.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.freemarker</groupId>
+        <artifactId>freemarker</artifactId>
+        <version>${freemarker.version}</version>
       </dependency>
 
       <dependency>
@@ -537,7 +536,7 @@
         </dependency>
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
+          <artifactId>log4j-slf4j2-impl</artifactId>
           <scope>provided</scope>
         </dependency>
         <dependency>
@@ -587,7 +586,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
+          <artifactId>log4j-slf4j2-impl</artifactId>
           <scope>provided</scope>
         </dependency>
         <dependency>

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/BuildArchivedBlogPostSiteMapAndPageConfig.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/BuildArchivedBlogPostSiteMapAndPageConfig.yaml
@@ -12,7 +12,7 @@ definitions:
         hee:blogPost)[(@hippo:availability='live') and not(@jcr:primaryType='nt:frozenNode')
         and (@hee:publicationDate____hour >= xs:dateTime('2020-08-04T13:00:00.000Z'))]/..
       hipposys:script: "package org.hippoecm.frontend.plugins.cms.admin.updater\r\n\
-        \r\nimport org.apache.commons.lang.StringUtils\r\nimport org.apache.jackrabbit.util.ISO8601\r\
+        \r\nimport org.apache.commons.lang3.StringUtils\r\nimport org.apache.jackrabbit.util.ISO8601\r\
         \nimport org.hippoecm.hst.configuration.HstNodeTypes\r\nimport org.hippoecm.repository.api.HippoNodeType\r\
         \nimport org.hippoecm.repository.util.JcrUtils\r\nimport org.onehippo.repository.update.BaseNodeUpdateVisitor\r\
         \n\r\nimport javax.jcr.Node\r\n\r\nclass BuildArchivedBlogPostSiteMapAndPageConfig\

--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls-rebuild/klsoldsitemaplearningacademyredirects.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/kls-rebuild/klsoldsitemaplearningacademyredirects.yaml
@@ -10,9 +10,9 @@
     jcr:mixinTypes: ['mix:referenceable']
     jcr:uuid: 9cb5a9e6-b2f6-4dd9-98cd-90779345c7a9
     hippo:availability: []
-    hippostd:holder: admin
     hippostd:retainable: false
     hippostd:state: draft
+    hippostd:transferable: false
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2025-07-17T11:39:22.112+01:00
     hippostdpubwf:lastModificationDate: 2026-05-27T13:47:02.253+01:00

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/test-live.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/test-live.yaml
@@ -1,0 +1,6 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/test-live:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 8080

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/test-live/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/test-live/uk.yaml
@@ -20,7 +20,7 @@ definitions:
             /hst:root:
               .meta:residual-child-node-category: content
               jcr:primaryType: hst:mount
-              hst:authenticated: false
+              hst:authenticated: true
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/kls

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/test-live/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/test-live/uk.yaml
@@ -1,0 +1,33 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/test-live/uk:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhost
+      hst:responseheaders: ['Content-Security-Policy: frame-ancestors ''self''', 'X-Frame-Options:
+          SAMEORIGIN']
+      hst:scheme: https
+      hst:showcontextpath: false
+      hst:showport: false
+      /nhs:
+        .meta:residual-child-node-category: content
+        jcr:primaryType: hst:virtualhost
+        /hee:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:virtualhost
+          /staging:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:virtualhost
+            /hst:root:
+              .meta:residual-child-node-category: content
+              jcr:primaryType: hst:mount
+              hst:authenticated: false
+              hst:homepage: root
+              hst:locale: en
+              hst:mountpoint: /hst:hee/hst:sites/kls
+              hst:responseheaders: ['robots: noindex, nofollow', 'Content-Security-Policy:
+                  frame-ancestors ''self''', 'X-Frame-Options: SAMEORIGIN']
+              hst:roles: [site.viewer]
+              /preview:
+                .meta:residual-child-node-category: content
+                jcr:primaryType: hst:mount
+                hst:type: preview

--- a/site/components/pom.xml
+++ b/site/components/pom.xml
@@ -13,8 +13,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax.servlet.jsp</groupId>
-      <artifactId>jsp-api</artifactId>
+      <groupId>jakarta.servlet.jsp</groupId>
+      <artifactId>jakarta.servlet.jsp-api</artifactId>
     </dependency>
 
     <dependency>

--- a/site/components/pom.xml
+++ b/site/components/pom.xml
@@ -50,6 +50,12 @@
     </dependency>
 
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
@@ -60,13 +66,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
     </dependency>
 
     <dependency>

--- a/site/components/pom.xml
+++ b/site/components/pom.xml
@@ -18,13 +18,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.taglibs</groupId>
-      <artifactId>taglibs-standard-spec</artifactId>
+      <groupId>com.bloomreach.xm</groupId>
+      <artifactId>taglibs-standard-spec-jakarta</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.taglibs</groupId>
-      <artifactId>taglibs-standard-impl</artifactId>
+      <groupId>com.bloomreach.xm</groupId>
+      <artifactId>taglibs-standard-impl-jakarta</artifactId>
     </dependency>
 
     <dependency>

--- a/site/components/src/main/java/uk/nhs/hee/web/components/CookiesBannerComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/CookiesBannerComponent.java
@@ -2,11 +2,9 @@ package uk.nhs.hee.web.components;
 
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
-import org.hippoecm.hst.core.parameters.ParametersInfo;
 import org.onehippo.cms7.essentials.components.CommonComponent;
-import org.onehippo.cms7.essentials.components.info.EssentialsDocumentComponentInfo;
 
-import javax.servlet.http.Cookie;
+import jakarta.servlet.http.Cookie;
 
 /**
  * Component class for {@code cookies} abstract base component

--- a/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageComponent.java
@@ -1,7 +1,7 @@
 package uk.nhs.hee.web.components;
 
 import com.google.common.base.Strings;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.HstQueryResult;
 import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;

--- a/site/components/src/main/java/uk/nhs/hee/web/components/PageNotFoundComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/PageNotFoundComponent.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * An extension of {@link LandingPageComponent} class to render {@code Page not found}.

--- a/site/components/src/main/java/uk/nhs/hee/web/components/SearchResultsComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/SearchResultsComponent.java
@@ -11,7 +11,7 @@ import org.onehippo.cms7.essentials.components.info.EssentialsDocumentComponentI
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;

--- a/site/components/src/main/java/uk/nhs/hee/web/tag/GetMiniHubGuidanceLink.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/tag/GetMiniHubGuidanceLink.java
@@ -12,8 +12,8 @@ import uk.nhs.hee.web.utils.MiniHubGuidanceLinkUtils;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.jsp.JspException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.jsp.JspException;
 
 import static org.hippoecm.hst.utils.TagUtils.writeOrSetVar;
 
@@ -33,7 +33,7 @@ public class GetMiniHubGuidanceLink extends HstLinkTag {
     private static final Logger log = LoggerFactory.getLogger(GetMiniHubGuidanceLink.class);
 
     /* (non-Javadoc)
-     * @see javax.servlet.jsp.tagext.TagSupport#doEndTag()
+     * @see jakarta.servlet.jsp.tagext.TagSupport#doEndTag()
      */
     @Override
     public int doEndTag() throws JspException {

--- a/site/components/src/main/java/uk/nhs/hee/web/utils/HstUtils.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/utils/HstUtils.java
@@ -1,6 +1,6 @@
 package uk.nhs.hee.web.utils;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hippoecm.hst.configuration.hosting.Mount;
 import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.HstQueryResult;

--- a/site/components/src/main/java/uk/nhs/hee/web/utils/StringUtils.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/utils/StringUtils.java
@@ -1,6 +1,6 @@
 package uk.nhs.hee.web.utils;
 
-import org.apache.commons.lang.WordUtils;
+import org.apache.commons.lang3.text.WordUtils;
 import uk.nhs.hee.web.constants.HeeNodeType;
 
 public class StringUtils extends org.apache.commons.lang3.StringUtils {

--- a/site/components/src/test/java/uk/nhs/hee/web/components/BreadcrumbComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/components/BreadcrumbComponentTest.java
@@ -15,25 +15,22 @@ import org.hippoecm.hst.core.request.ResolvedMount;
 import org.hippoecm.hst.core.request.ResolvedSiteMapItem;
 import org.hippoecm.hst.mock.core.component.MockHstRequest;
 import org.hippoecm.hst.site.HstServices;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.onehippo.cms7.essentials.components.ext.DoBeforeRenderExtension;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import uk.nhs.hee.web.components.beans.BreadcrumbLinkTest;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
-@PrepareForTest({HstServices.class, RequestContextProvider.class})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class BreadcrumbComponentTest {
     // Home Page Title and URL
     private static final String homePageTitle = "Home";
@@ -53,6 +50,9 @@ public class BreadcrumbComponentTest {
     private HstLinkCreator hstLinkCreator;
     @Mock
     private Mount mount;
+
+    private MockedStatic<HstServices> mockedHstServices;
+    private MockedStatic<RequestContextProvider> mockedRequestContextProvider;
 
     private BreadcrumbComponent systemUnderTest;
 
@@ -75,10 +75,11 @@ public class BreadcrumbComponentTest {
 
         // Do nothing when org.onehippo.cms7.essentials.components.CommonComponent#doBeforeRender
         // has been called from BreadcrumbComponent via super.doBeforeRender(request, response).
-        mockStatic(HstServices.class, RequestContextProvider.class);
-        when(HstServices.getComponentManager()).thenReturn(componentManager);
+        mockedHstServices = mockStatic(HstServices.class);
+        mockedRequestContextProvider = mockStatic(RequestContextProvider.class);
+        mockedHstServices.when(HstServices::getComponentManager).thenReturn(componentManager);
         when(componentManager.getComponent(DoBeforeRenderExtension.class.getName())).thenReturn(null);
-        when(RequestContextProvider.get()).thenReturn(hstRequestContext);
+        mockedRequestContextProvider.when(RequestContextProvider::get).thenReturn(hstRequestContext);
         when(hstRequestContext.isChannelManagerPreviewRequest()).thenReturn(false);
 
         // Home SiteMapItem
@@ -86,6 +87,12 @@ public class BreadcrumbComponentTest {
         when(hstSiteMap.getSiteMapItemByRefId("root")).thenReturn(homeHstSiteMapItem);
 
         systemUnderTest = spy(new BreadcrumbComponent());
+    }
+
+    @After
+    public void tearDown() {
+        mockedHstServices.close();
+        mockedRequestContextProvider.close();
     }
 
     @Test

--- a/site/components/src/test/java/uk/nhs/hee/web/components/BreadcrumbComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/components/BreadcrumbComponentTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "javax.script.*"})
+@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
 @PrepareForTest({HstServices.class, RequestContextProvider.class})
 public class BreadcrumbComponentTest {
     // Home Page Title and URL

--- a/site/components/src/test/java/uk/nhs/hee/web/components/CookiesPageComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/components/CookiesPageComponentTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "javax.script.*"})
+@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
 @PrepareForTest({HstServices.class, RequestContextProvider.class, ContentBlocksUtils.class})
 public class CookiesPageComponentTest {
 

--- a/site/components/src/test/java/uk/nhs/hee/web/components/CookiesPageComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/components/CookiesPageComponentTest.java
@@ -9,16 +9,16 @@ import org.hippoecm.hst.core.container.ComponentManager;
 import org.hippoecm.hst.core.request.HstRequestContext;
 import org.hippoecm.hst.mock.core.component.MockHstRequest;
 import org.hippoecm.hst.site.HstServices;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.onehippo.cms7.essentials.components.ext.DoBeforeRenderExtension;
 import org.onehippo.cms7.essentials.components.info.EssentialsDocumentComponentInfo;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import uk.nhs.hee.web.beans.Guidance;
 import uk.nhs.hee.web.utils.ContentBlocksUtils;
 
@@ -26,11 +26,8 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
-@PrepareForTest({HstServices.class, RequestContextProvider.class, ContentBlocksUtils.class})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class CookiesPageComponentTest {
 
     private static final String COMPONENT_PARAMETER_NAME_DOCUMENT = "document";
@@ -62,6 +59,10 @@ public class CookiesPageComponentTest {
     @Mock
     private Guidance mockFallbackChannelCookieGuidance;
 
+    private MockedStatic<HstServices> mockedHstServices;
+    private MockedStatic<RequestContextProvider> mockedRequestContextProvider;
+    private MockedStatic<ContentBlocksUtils> mockedContentBlocksUtils;
+
     private CookiesPageComponent systemUnderTest;
 
     @Before
@@ -69,14 +70,16 @@ public class CookiesPageComponentTest {
         // Mocks & stubs
         // Do nothing when org.onehippo.cms7.essentials.components.CommonComponent#doBeforeRender
         // has been called from CookiesPageComponent via super.doBeforeRender(request, response).
-        mockStatic(HstServices.class, RequestContextProvider.class);
-        when(HstServices.getComponentManager()).thenReturn(mockComponentManager);
+        mockedHstServices = mockStatic(HstServices.class);
+        mockedRequestContextProvider = mockStatic(RequestContextProvider.class);
+        mockedHstServices.when(HstServices::getComponentManager).thenReturn(mockComponentManager);
         when(mockComponentManager.getComponent(DoBeforeRenderExtension.class.getName())).thenReturn(null);
-        when(RequestContextProvider.get()).thenReturn(mockHstRequestContext);
+        mockedRequestContextProvider.when(RequestContextProvider::get).thenReturn(mockHstRequestContext);
         when(mockHstRequestContext.isChannelManagerPreviewRequest()).thenReturn(false);
 
-        mockStatic(ContentBlocksUtils.class);
-        when(ContentBlocksUtils.getValueListMaps(Mockito.anyList())).thenReturn(Collections.emptyMap());
+        mockedContentBlocksUtils = mockStatic(ContentBlocksUtils.class);
+        mockedContentBlocksUtils.when(() -> ContentBlocksUtils.getValueListMaps(Mockito.anyList()))
+                .thenReturn(Collections.emptyMap());
 
         // Stubbing for org.onehippo.cms7.essentials.components.EssentialsDocumentComponent.doBeforeRender call
         when(mockEssentialsDocumentComponentInfo.getDocument()).thenReturn(COMPONENT_PARAMETER_VALUE_DOCUMENT);
@@ -103,6 +106,13 @@ public class CookiesPageComponentTest {
                 return null;
             }
         });
+    }
+
+    @After
+    public void tearDown() {
+        mockedHstServices.close();
+        mockedRequestContextProvider.close();
+        mockedContentBlocksUtils.close();
     }
 
     @Test

--- a/site/components/src/test/java/uk/nhs/hee/web/content/rewriter/impl/MiniHubGuidanceLinkRewriterTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/content/rewriter/impl/MiniHubGuidanceLinkRewriterTest.java
@@ -4,14 +4,14 @@ import org.hippoecm.hst.configuration.hosting.Mount;
 import org.hippoecm.hst.core.linking.HstLink;
 import org.hippoecm.hst.core.request.HstRequestContext;
 import org.hippoecm.repository.api.HippoNodeType;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Spy;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.nhs.hee.web.utils.HstUtils;
 import uk.nhs.hee.web.utils.MiniHubGuidanceLinkUtils;
 
@@ -19,17 +19,10 @@ import javax.jcr.*;
 import javax.jcr.nodetype.NodeType;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({
-        MiniHubGuidanceLinkUtils.class,
-        HstUtils.class
-})
-@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class MiniHubGuidanceLinkRewriterTest {
     @Mock
     private Session mockJCRSession;
@@ -66,10 +59,15 @@ public class MiniHubGuidanceLinkRewriterTest {
     @Mock
     private NodeIterator mockMiniHubNodeIterator;
 
+    private MockedStatic<MiniHubGuidanceLinkUtils> mockedMiniHubGuidanceLinkUtils;
+    private MockedStatic<HstUtils> mockedHstUtils;
+
     @Before
     public void setUp() throws Exception {
-        mockStatic(MiniHubGuidanceLinkUtils.class, HstUtils.class);
-        when(HstUtils.isPageNotFound(any(HstLink.class), anyBoolean(), eq(mockHstRequestContext), any(Mount.class)))
+        mockedMiniHubGuidanceLinkUtils = mockStatic(MiniHubGuidanceLinkUtils.class);
+        mockedHstUtils = mockStatic(HstUtils.class);
+        mockedHstUtils.when(() -> HstUtils.isPageNotFound(
+                any(HstLink.class), anyBoolean(), eq(mockHstRequestContext), any(Mount.class)))
                 .thenReturn(true);
 
         when(mockSuperClassLink.getPath()).thenReturn("pagenotfound");
@@ -96,11 +94,18 @@ public class MiniHubGuidanceLinkRewriterTest {
         when(mockReferencedNode.hasNode(referencedNodeName)).thenReturn(true);
     }
 
+    @After
+    public void tearDown() {
+        mockedMiniHubGuidanceLinkUtils.close();
+        mockedHstUtils.close();
+    }
+
     @Test
     public void getLink_WithLinkFromSuperClassIsNotPageNotFound_ReturnsLinkFromSuperClass() {
         // Mocks & stubs
         when(mockSuperClassLink.getPath()).thenReturn("copyright");
-        when(HstUtils.isPageNotFound(any(HstLink.class), anyBoolean(), eq(mockHstRequestContext), any(Mount.class)))
+        mockedHstUtils.when(() -> HstUtils.isPageNotFound(
+                any(HstLink.class), anyBoolean(), eq(mockHstRequestContext), any(Mount.class)))
                 .thenReturn(false);
 
         // Execute the method to be tested
@@ -186,8 +191,9 @@ public class MiniHubGuidanceLinkRewriterTest {
             throws RepositoryException {
         // Mocks & stubs
         when(mockDocumentNode.isNodeType("hee:guidance")).thenReturn(false);
-        when(MiniHubGuidanceLinkUtils.getLink(eq(mockReferencedNode), anyBoolean(), eq(mockHstRequestContext),
-                any(Mount.class))).thenReturn(null);
+        mockedMiniHubGuidanceLinkUtils.when(() -> MiniHubGuidanceLinkUtils.getLink(
+                eq(mockReferencedNode), anyBoolean(), eq(mockHstRequestContext), any(Mount.class)))
+                .thenReturn(null);
 
         // Execute the method to be tested
         final HstLink hstLink = systemUnderTest.getLink(
@@ -204,8 +210,9 @@ public class MiniHubGuidanceLinkRewriterTest {
     public void getLink_WithReferencedGuidanceNodeNotAssociatedToAnyMiniHubDocument_ReturnsLinkFromSuperClass() {
         // Mocks & stubs
         when(mockMiniHubNodeIterator.hasNext()).thenReturn(false);
-        when(MiniHubGuidanceLinkUtils.getLink(eq(mockReferencedNode), anyBoolean(), eq(mockHstRequestContext),
-                any(Mount.class))).thenReturn(null);
+        mockedMiniHubGuidanceLinkUtils.when(() -> MiniHubGuidanceLinkUtils.getLink(
+                eq(mockReferencedNode), anyBoolean(), eq(mockHstRequestContext), any(Mount.class)))
+                .thenReturn(null);
 
         // Execute the method to be tested
         final HstLink hstLink = systemUnderTest.getLink(
@@ -221,8 +228,9 @@ public class MiniHubGuidanceLinkRewriterTest {
     @Test
     public void getLink_WithReferencedGuidanceNodeAssociatedToAMiniHubDocument_ReturnsLinkFromSuperClass() {
         // Mocks & stubs
-        when(MiniHubGuidanceLinkUtils.getLink(eq(mockReferencedNode), anyBoolean(), eq(mockHstRequestContext),
-                any(Mount.class))).thenReturn(mockMiniHubGuidanceLink);
+        mockedMiniHubGuidanceLinkUtils.when(() -> MiniHubGuidanceLinkUtils.getLink(
+                eq(mockReferencedNode), anyBoolean(), eq(mockHstRequestContext), any(Mount.class)))
+                .thenReturn(mockMiniHubGuidanceLink);
 
         // Execute the method to be tested
         final HstLink hstLink = systemUnderTest.getLink(

--- a/site/components/src/test/java/uk/nhs/hee/web/content/rewriter/impl/MiniHubGuidanceLinkRewriterTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/content/rewriter/impl/MiniHubGuidanceLinkRewriterTest.java
@@ -29,7 +29,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
         MiniHubGuidanceLinkUtils.class,
         HstUtils.class
 })
-@PowerMockIgnore({"javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "javax.script.*"})
+@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
 public class MiniHubGuidanceLinkRewriterTest {
     @Mock
     private Session mockJCRSession;

--- a/site/components/src/test/java/uk/nhs/hee/web/utils/TableUtilsTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/utils/TableUtilsTest.java
@@ -26,8 +26,8 @@ public class TableUtilsTest {
     private static final String COMPLETE_ELEMENT_THEAD = "<table>" +
             "<thead>" +
             "<tr>" +
-            "<th>Head 1</th" +
-            "<th>Head 2</th" +
+            "<th>Head 1</th>" +
+            "<th>Head 2</th>" +
             "</tr>" +
             "</thead>" +
             "<tbody>" +
@@ -45,8 +45,8 @@ public class TableUtilsTest {
             "<caption>I am a caption</caption>"+
             "<thead>"+
             "<tr>" +
-            "<th>Head 1</th" +
-            "<th>Head 2</th" +
+            "<th>Head 1</th>" +
+            "<th>Head 2</th>" +
             "</tr>" +
             "</thead>" +
             "<tbody>" +

--- a/site/components/src/test/java/uk/nhs/hee/web/utils/ValueListUtilsTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/utils/ValueListUtilsTest.java
@@ -2,15 +2,15 @@ package uk.nhs.hee.web.utils;
 
 import org.hippoecm.hst.container.RequestContextProvider;
 import org.hippoecm.hst.core.request.HstRequestContext;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.onehippo.forge.selection.hst.contentbean.ValueList;
 import org.onehippo.forge.selection.hst.util.SelectionUtil;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -18,15 +18,9 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
-@PrepareForTest({
-        RequestContextProvider.class,
-        SelectionUtil.class
-})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ValueListUtilsTest {
 
     @Mock
@@ -35,10 +29,20 @@ public class ValueListUtilsTest {
     @Mock
     private HstRequestContext mockHstRequestContext;
 
+    private MockedStatic<RequestContextProvider> mockedRequestContextProvider;
+    private MockedStatic<SelectionUtil> mockedSelectionUtil;
+
     @Before
     public void setUp() {
-        mockStatic(RequestContextProvider.class, SelectionUtil.class);
-        when(RequestContextProvider.get()).thenReturn(mockHstRequestContext);
+        mockedRequestContextProvider = mockStatic(RequestContextProvider.class);
+        mockedSelectionUtil = mockStatic(SelectionUtil.class);
+        mockedRequestContextProvider.when(RequestContextProvider::get).thenReturn(mockHstRequestContext);
+    }
+
+    @After
+    public void tearDown() {
+        mockedRequestContextProvider.close();
+        mockedSelectionUtil.close();
     }
 
     @Test
@@ -56,9 +60,9 @@ public class ValueListUtilsTest {
             }
         });
 
-        when(SelectionUtil.getValueListByIdentifier(eq(valueListIdentifier + "_" + channel),
-                eq(mockHstRequestContext))).thenReturn(mockValueList);
-        when(SelectionUtil.valueListAsMap(mockValueList)).thenReturn(blogCategoriesMap);
+        mockedSelectionUtil.when(() -> SelectionUtil.getValueListByIdentifier(
+                eq(valueListIdentifier + "_" + channel), eq(mockHstRequestContext))).thenReturn(mockValueList);
+        mockedSelectionUtil.when(() -> SelectionUtil.valueListAsMap(mockValueList)).thenReturn(blogCategoriesMap);
 
         // Execute the method to be tested
         final Map<String, String> actualBlogCategoriesMap =
@@ -82,9 +86,9 @@ public class ValueListUtilsTest {
             }
         });
 
-        when(SelectionUtil.getValueListByIdentifier(eq(valueListIdentifier), eq(mockHstRequestContext)))
-                .thenReturn(mockValueList);
-        when(SelectionUtil.valueListAsMap(mockValueList)).thenReturn(navMapRegionsMap);
+        mockedSelectionUtil.when(() -> SelectionUtil.getValueListByIdentifier(
+                eq(valueListIdentifier), eq(mockHstRequestContext))).thenReturn(mockValueList);
+        mockedSelectionUtil.when(() -> SelectionUtil.valueListAsMap(mockValueList)).thenReturn(navMapRegionsMap);
 
         // Execute the method to be tested
         final Map<String, String> actualNavMapRegionsMap = ValueListUtils.getValueListMap(valueListIdentifier);
@@ -98,8 +102,8 @@ public class ValueListUtilsTest {
         // Mocks & stubs
         final String valueListIdentifier = "non-existent-value-list";
 
-        when(SelectionUtil.getValueListByIdentifier(eq(valueListIdentifier), eq(mockHstRequestContext)))
-                .thenReturn(mockValueList);
+        mockedSelectionUtil.when(() -> SelectionUtil.getValueListByIdentifier(
+                eq(valueListIdentifier), eq(mockHstRequestContext))).thenReturn(mockValueList);
 
         // Execute the method to be tested
         final Map<String, String> actualNavMapRegionsMap = ValueListUtils.getValueListMap(valueListIdentifier);

--- a/site/components/src/test/java/uk/nhs/hee/web/utils/ValueListUtilsTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/utils/ValueListUtilsTest.java
@@ -22,7 +22,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "javax.script.*"})
+@PowerMockIgnore({"jakarta.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*", "jakarta.script.*"})
 @PrepareForTest({
         RequestContextProvider.class,
         SelectionUtil.class

--- a/site/components/src/test/resources/log4j2.xml
+++ b/site/components/src/test/resources/log4j2.xml
@@ -22,7 +22,7 @@
     <Logger name="org.hippoecm.hst" level="warn"/>
     <Logger name="freemarker" level="warn"/>
     <Logger name="org.apache.cxf" level="warn"/>
-    <Logger name="javax.ws.rs.core" level="warn"/>
+    <Logger name="jakarta.ws.rs.core" level="warn"/>
     <Logger name="org.apache.commons.pool" level="warn"/>
     <Logger name="org.apache.commons.beanutils" level="warn"/>
 

--- a/site/webapp/pom.xml
+++ b/site/webapp/pom.xml
@@ -45,6 +45,10 @@
       <groupId>org.onehippo.cms7</groupId>
       <artifactId>hippo-plugin-robotstxt-addon-hcm-site</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/site/webapp/pom.xml
+++ b/site/webapp/pom.xml
@@ -65,7 +65,7 @@
     <plugins>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
+        <artifactId>cargo-maven3-plugin</artifactId>
         <configuration>
           <configuration>
             <type>runtime</type>

--- a/site/webapp/pom.xml
+++ b/site/webapp/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/assembly/shared-lib-component.xml
+++ b/src/main/assembly/shared-lib-component.xml
@@ -13,7 +13,7 @@
         <include>org.onehippo.cms7.hst:hst-api</include>
         <include>org.slf4j:slf4j-api</include>
         <include>org.slf4j:jcl-over-slf4j</include>
-        <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
+        <include>org.apache.logging.log4j:log4j-slf4j2-impl</include>
         <include>org.apache.logging.log4j:log4j-api</include>
         <include>org.apache.logging.log4j:log4j-core</include>
       </includes>

--- a/src/main/docker/assembly/docker-db-libs.xml
+++ b/src/main/docker/assembly/docker-db-libs.xml
@@ -14,7 +14,7 @@
       <outputDirectory>db-drivers/mysql</outputDirectory>
       <scope>provided</scope>
       <includes>
-        <include>com.mysql:mysql-connector-j</include>
+        <include>org.mariadb.jdbc:mariadb-java-client</include>
       </includes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
Staged the upgrade in patches:
15.7.3, 15.7.8, 16.0.0, 16.9.1 and then to 16.9.2 due to issues with deprecated libraries causing unexpected behaviour.

- Java 11 to Java 17.
- javax to jakarta namespace (imports, Maven repos, Tomcat 9 to 10).
- PowerMock removed, migrated to Mockito. Powermock is no longer maintained so the move to mockito was necessary.
- commons-lang 2.x removed at 16.2.0, migrated all usages to lang3 across Java sources and one embedded Groovy updater script.
- SLF4J 1 to 2. log4j-slf4j-impl renamed to log4j-slf4j2-impl across dist profiles and shared-lib-component.
- MySQL connector swapped for MariaDB client (required at 16.9.0).
- jsoup pin removed. The project had 1.17.2 hardcoded, 16.9.1 requires 1.18.x+ for the TagSet API. Removing the pin lets it inherit 1.21.2 from parent. This also exposed two malformed </th tags in TableUtilsTest that jsoup's old lenient parser was silently papering over.
- JSTL taglibs swapped from org.apache.taglibs (javax) to com.bloomreach.xm jakarta variants - Tomcat 10 refuses the legacy TLD on startup. The Bloomreach jar keeps the legacy URI so no FTL template changes needed landed on 16.9.2 rather than 16.9.1, 16.8 introduced a commons-fileupload2 M4/M5 conflict that broke CMS file uploads, 16.9.2 ships Wicket 10.9.1 which resolves it cleanly.